### PR TITLE
Fixing incorrect module resolution (webpack)

### DIFF
--- a/config/client/poi.config.js
+++ b/config/client/poi.config.js
@@ -51,13 +51,12 @@ module.exports = (options, req) => ({
     favicon: `client/${brand.globals.FAVICON}`
   },
   define: { BRAND_CONFIG: brand.globals },
-  // ESnext modules that require compilation
-  transformModules: ['auto-bind'],
   webpack(config) {
     config.module.rules.push(...rules);
     return config;
   },
   extendWebpack(config) {
+    configureModuleResolution(config);
     config.resolve.alias.merge(aliases);
     applyBrandConfig(config);
     if (options.mode !== 'production') return;
@@ -76,3 +75,11 @@ module.exports = (options, req) => ({
     }
   }
 });
+
+// NOTE: Remove absolute path to local `node_modules` from configuration
+// https://github.com/webpack/webpack/issues/6538#issuecomment-367324775
+function configureModuleResolution(config) {
+  const localModules = path.join(rootPath, 'node_modules');
+  config.resolve.modules.delete(localModules);
+  config.resolveLoader.modules.delete(localModules);
+}


### PR DESCRIPTION
This PR addresses incorrect webpack config defaults generated by poi. Poi adds absolute path to local `node_modules` to module resolution config thus causing webpack to search for 2nd row dependencies (dependencies of dependencies) inside local `node_modules` 🤦‍♂️ 

This caused build errors in on recent version of `develop` due to having `auto-bind` as both `tailor` and `vuex-module` dependency...