### PR TITLE
Add label to activity example schema

### DIFF
--- a/.activities-rc.json.example
+++ b/.activities-rc.json.example
@@ -4,6 +4,7 @@
     "name": "Example Course",
     "structure": [{
       "type": "GOAL",
+      "label": "Goal",
       "color": "#ff6590",
       "level": 1,
       "meta":[{


### PR DESCRIPTION
Per the new [schema validation](https://github.com/ExtensionEngine/tailor/blob/develop/config/shared/schema-validation.js#L20) a label is required for for the activities structures, and the example won't work out-of-the-box without it.
