### PR TITLE
Lower minimum embed element height

### DIFF
--- a/client/components/editor/toolbar/EmbedToolbar.vue
+++ b/client/components/editor/toolbar/EmbedToolbar.vue
@@ -12,7 +12,7 @@
           v-model="height"
           v-validate="{
             rules: {
-              required: true, numeric: true, min_value: 300, max_value: 3000
+              required: true, numeric: true, min_value: 50, max_value: 3000
             }
           }"
           @input="onChange"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14431,7 +14431,7 @@
     "vue-video-player": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/vue-video-player/-/vue-video-player-3.1.4.tgz",
-      "integrity": "sha1-cAmwbc7EObPqZFGDIX0xTL8NN/0=",
+      "integrity": "sha512-CqVvhy2QSDRxXfaHn029Cpz+mbV2gubIcdZE5Uu1e7f0ZfpdqpuqnSYyE50nUXzM3zfa7TaYOARpLsY3FdLtOQ==",
       "requires": {
         "video.js": "5.20.4"
       },
@@ -14448,7 +14448,7 @@
         "video.js": {
           "version": "5.20.4",
           "resolved": "https://registry.npmjs.org/video.js/-/video.js-5.20.4.tgz",
-          "integrity": "sha1-hdWBKeVoUnzMF5+V9IX1R+48LgY=",
+          "integrity": "sha512-DkwZcYDN5+qNp3c1y+9N6cQ3XSoFin1dEsEstIRGmALtmh71M8JIPage0S/AC5HzCc7QdUBeeTYHLKZectB2TA==",
           "requires": {
             "babel-runtime": "6.26.0",
             "global": "4.3.0",


### PR DESCRIPTION
- Fixes #98 
- Minimum `iframe` height is lowered to 50 pixels whereas default one is left at 300 pixels.