### PR TITLE
Navbar responsive

### DIFF
--- a/client/components/common/Navbar.vue
+++ b/client/components/common/Navbar.vue
@@ -1,32 +1,36 @@
 <template>
   <nav v-if="user" class="navbar navbar-default navbar-fixed-top">
     <div class="container-fluid">
-      <div class="navbar-header">
-        <router-link :to="{ name: 'catalog' }" class="navbar-brand">
-          <img :src="logo" alt="Logo" class="logo"/>
-          <div class="title">{{ title }}</div>
-        </router-link>
-      </div>
-      <router-link
-        v-if="course"
-        :to="{ name: 'course', params: { courseId: course.id }}"
-        class="course-title">
-        <span class="navbar-acronym">
-          <span>{{ courseAcronym }}</span>
-        </span>
-        {{ course.name }}
-      </router-link>
-      <ul class="nav navbar-nav navbar-right">
-        <li class="dropdown">
-          <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-            Welcome {{ user.email }}
-            <span class="icon mdi mdi-menu-down"></span>
-          </a>
-          <ul class="dropdown-menu">
-            <li><a @click="logout" href="#">Log out</a></li>
+      <div class="row">
+        <div class="navbar-header col-xs-8 col-sm-7 col-md-7">
+          <router-link :to="{ name: 'catalog' }" class="navbar-brand">
+            <img :src="logo" alt="Logo" class="logo"/>
+            <div class="title hidden-xs">{{ title }}</div>
+          </router-link>
+          <router-link
+            v-if="course"
+            :to="{ name: 'course', params: { courseId: course.id }}"
+            class="course-title">
+            <span class="navbar-acronym">
+              <span>{{ courseAcronym }}</span>
+            </span>
+            {{ course.name }}
+          </router-link>
+        </div>
+        <div class="col-xs-4 col-sm-5 col-md-5">
+          <ul class="nav navbar-nav navbar-right">
+            <li class="dropdown">
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+                Welcome <span class="hidden-xs">{{ user.email }}</span>
+                <span class="icon mdi mdi-menu-down"></span>
+              </a>
+              <ul class="dropdown-menu">
+                <li><a @click="logout" href="#">Log out</a></li>
+              </ul>
+            </li>
           </ul>
-        </li>
-      </ul>
+        </div>
+      </div>
     </div>
   </nav>
 </template>
@@ -82,11 +86,16 @@ $bg-color: #fff;
   .navbar-brand {
     height: $nav-height;
     padding: 0;
+    max-width: 30%;
 
     .logo {
       float: left;
       height: 36px;
       margin: 12px 25px 0 20px;
+
+      @media only screen and (max-width: 767px) {
+        margin: 12px 10px 0;
+      }
     }
 
     .title {
@@ -95,11 +104,12 @@ $bg-color: #fff;
       font-size: 18px;
       line-height: $nav-height;
     }
+
   }
 
   .course-title {
     float: left;
-    width: 50%;
+    width: 60%;
     margin-left: 38px;
     color: $font-color;
     font-size: 16px;
@@ -111,17 +121,15 @@ $bg-color: #fff;
     text-decoration: none;
     overflow: hidden;
 
+    @media only screen and (max-width: 767px) {
+      margin-left: 10px;
+      font-size: 12px;
+    }
+
     &:hover {
       color: darken($font-color, 20%);
     }
 
-    @media (max-width: 1200px) {
-      width: 40%;
-    }
-
-    @media (max-width: 1000px) {
-      width: 25%;
-    }
   }
 
   .navbar-acronym {
@@ -131,18 +139,53 @@ $bg-color: #fff;
   }
 
   .navbar-nav {
+
+    @media only screen and (max-width: 767px) {
+      margin: 0;
+      font-size: 12px;
+    }
+
+    .dropdown .dropdown-menu {
+      background-color: $bg-color;
+      box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+      margin: 0;
+      padding: 0;
+
+      @media only screen and (min-width: 320px) {
+        float: right;
+        &:hover {
+          background-color: #f5f5f5;
+        }
+      }
+    }
+
     .dropdown a {
-      padding: 20px 10px;
       color: $font-color;
     }
 
-    .dropdown-menu a {
-      padding: 12px 15px;
+    .dropdown a.dropdown-toggle {
+      line-height: $nav-height;
+      margin: 0;
+      padding: 0 0 0 15px;
+      text-align: right;
+    }
+
+    .dropdown-menu > li > a {
+      @media only screen and (min-width: 320px) {
+        line-height: initial;
+        padding: 12px 15px;
+      }
     }
 
     ul {
       border-radius: 2px;
     }
   }
+
+  .navbar-right {
+    margin-left: -15px;
+    margin-right: -15px;
+  }
+
 }
 </style>


### PR DESCRIPTION
Fixed breaking of default navbar on smaller screens:

- created the two bootstrap columns as navbar content containers for better sizing
- first column contains nav brand and course title
- second column contains user dropdown
- "Tailor" title is set to hide on extra small screens leaving just the Tailor logo as the brand
- user email is also set to hide on xs screens leaving only "Welcome" visible
- some font size in the navbar is also deduced in order all navbar content to fit in one row

This way the default navbar doesn't break on any screen larger than 319px. 