### PR TITLE
Add content containers min and max count

### DIFF
--- a/.activities-rc.json.example
+++ b/.activities-rc.json.example
@@ -32,7 +32,9 @@
     "contentContainers": [{
       "type": "PAGE",
       "label": "Page",
-      "multiple": false
+      "multiple": false,
+      "min": 1,
+      "max": 1
     }]
   }]
 }

--- a/client/components/editor/structure/ContentContainers/Container.vue
+++ b/client/components/editor/structure/ContentContainers/Container.vue
@@ -2,6 +2,7 @@
   <div>
     <div class="actions">
       <button
+        v-if="!deleteDisabled"
         @click="deleteContainer"
         class="btn btn-default btn-material pull-right"
         type="button">
@@ -43,7 +44,8 @@ export default {
     container: { type: Object, required: true },
     types: { type: Array, default: null },
     name: { type: String, required: true },
-    layout: { type: Boolean, required: true }
+    layout: { type: Boolean, required: true },
+    deleteDisabled: { type: Boolean, default: false }
   },
   computed: {
     ...mapGetters(['tes']),

--- a/client/components/editor/structure/ContentContainers/index.vue
+++ b/client/components/editor/structure/ContentContainers/index.vue
@@ -11,11 +11,12 @@
       :types="types"
       :name="name"
       :layout="layout"
+      :deleteDisabled="deleteDisabled"
       :class="`${name}-container`"
       @delete="deleteContainer(container)"
       class="content-container">
     </content-container>
-    <div v-if="addBtnEnabled">
+    <div v-if="!addDisabled">
       <button @click="addContainer" class="add-btn btn btn-primary btn-material">
         <span class="add-icon mdi mdi-plus"></span>
         Create {{ name }}
@@ -44,14 +45,20 @@ export default {
     type: { type: String, required: true },
     label: { type: String, required: true },
     multiple: { type: Boolean, default: false },
-    layout: { type: Boolean, default: true }
+    layout: { type: Boolean, default: true },
+    min: { type: Number, default: null },
+    max: { type: Number, default: null }
   },
   computed: {
     name() {
       return this.label.toLowerCase();
     },
-    addBtnEnabled() {
-      return !(!this.multiple && this.containerGroup.length);
+    addDisabled() {
+      return (!this.multiple && this.containerGroup.length) ||
+        (this.max && this.containerGroup.length >= this.max);
+    },
+    deleteDisabled() {
+      return this.min && this.containerGroup.length <= this.min;
     },
     nextPosition() {
       const last = get(maxBy(this.containerGroup, 'position'), 'position', 0);

--- a/client/components/editor/structure/ContentContainers/index.vue
+++ b/client/components/editor/structure/ContentContainers/index.vue
@@ -32,6 +32,7 @@ import EventBus from 'EventBus';
 import get from 'lodash/get';
 import { mapActions } from 'vuex-module';
 import maxBy from 'lodash/maxBy';
+import times from 'lodash/times';
 
 const appChannel = EventBus.channel('app');
 
@@ -78,6 +79,10 @@ export default {
         action: () => this.remove(container)
       });
     }
+  },
+  created() {
+    if (!this.min || this.containerGroup.length >= this.min) return;
+    return times(this.min - this.containerGroup.length, this.addContainer);
   },
   filters: {
     capitalize(val) {

--- a/config/shared/schema-validation.js
+++ b/config/shared/schema-validation.js
@@ -46,6 +46,9 @@ const schema = yup.object().shape({
     label: yup.string().min(2).max(100).required(),
     types: yup.array().of(yup.string().min(2).max(20)),
     multiple: yup.boolean(),
+    min: yup.number().integer().min(0).when('multiple', conditionalMax(1)),
+    max: yup.number().integer().min(yup.ref('min'))
+      .when('multiple', conditionalMax(1)),
     displayHeading: yup.boolean()
   }))
 });
@@ -60,3 +63,7 @@ module.exports = function (config) {
     throw err;
   }
 };
+
+function conditionalMax(max) {
+  return (field, schema) => field ? schema : schema.max(max);
+}


### PR DESCRIPTION
- `min` and `max` numerical config fields are added to content containers config
- `min` number of containers are auto-created upon the opening of activity editor
-  If `min` is reached further deletion is disabled
-  If `max` is reached further addition is disabled