### PR TITLE
Fix reset password validation

### DIFF
--- a/client/components/auth/ResetPassword.vue
+++ b/client/components/auth/ResetPassword.vue
@@ -5,6 +5,7 @@
       <div :class="{ 'has-error': vErrors.has('password') }" class="form-group">
         <input
           v-validate="{ rules: { required: true, min: 6, alphanumerical: true } }"
+          ref="password"
           v-model="password"
           class="form-control"
           name="password"


### PR DESCRIPTION
This PR fixes issue with password reset form and invalid `confirm` password validation rule.
Missing `ref` on the `password` field is added so the confirm validation rule on password confirmation filed can properly target password field. See the [docs](https://baianat.github.io/vee-validate/guide/rules.html#confirmed) for more info.