### PR TITLE
Pin vee-validate package to 2.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "truncate": "^2.0.0",
     "untildify": "^3.0.2",
     "url-join": "^1.1.0",
-    "vee-validate": "^2.0.4",
+    "vee-validate": "2.0.4",
     "vue": "^2.5.17",
     "vue-aplayer": "^1.4.1",
     "vue-avatar": "^2.1.1",


### PR DESCRIPTION
New version of vee-validate (2.1.3) breaks the password reset form validation.

![screenshot from 2018-11-28 14-38-13](https://user-images.githubusercontent.com/2808092/49156069-bff5f000-f31c-11e8-8ddc-3e61ba0cabdb.png)
