### PR TITLE
Tweak activity deletion confirmation modal

### DIFF
--- a/client/components/common/ConfirmationModal.vue
+++ b/client/components/common/ConfirmationModal.vue
@@ -5,7 +5,7 @@
     </div>
     <div slot="body">
       Are you sure you want to delete
-      <span v-if="info">{{ context.type }} <b>{{ info }}</b></span>
+      <span v-if="context.info">{{ context.type }} <b>{{ context.info }}</b></span>
       <span v-else>this {{ context.type }}</span>?
     </div>
     <div slot="footer">
@@ -32,7 +32,7 @@ import { focus } from 'vue-focus';
 import Modal from './Modal';
 
 const appChannel = EventBus.channel('app');
-const defaultData = { item: {}, type: '' };
+const defaultData = { item: {}, type: '', info: '' };
 
 export default {
   data() {
@@ -43,7 +43,7 @@ export default {
   },
   computed: {
     info() {
-      return this.context.item.name;
+      return this.context.info || this.context.item.name;
     }
   },
   methods: {

--- a/client/components/course/Sidebar/Header.vue
+++ b/client/components/course/Sidebar/Header.vue
@@ -22,6 +22,7 @@ import { mapActions, mapGetters, mapMutations } from 'vuex-module';
 import sortBy from 'lodash/sortBy';
 
 const appChannel = EventBus.channel('app');
+const TREE_VIEW = 'tree-view';
 
 export default {
   computed: {
@@ -29,6 +30,11 @@ export default {
     isEditable() {
       const type = get(this.activity, 'type');
       return type && isEditable(type);
+    },
+    info() {
+      const name = get(this.activity.data, 'name');
+      if (this.$route.name !== TREE_VIEW) return name;
+      return `${this.activity.id}: ${name}`;
     }
   },
   methods: {
@@ -45,6 +51,7 @@ export default {
       appChannel.emit('showConfirmationModal', {
         type: 'activity',
         item: this.activity,
+        info: this.info,
         action: () => {
           const { parentId } = this.activity;
           const rootFilter = it => !it.parentId && (it.id !== this.activity.id);

--- a/client/components/course/Sidebar/Header.vue
+++ b/client/components/course/Sidebar/Header.vue
@@ -32,9 +32,9 @@ export default {
       return type && isEditable(type);
     },
     info() {
-      const name = get(this.activity.data, 'name');
-      if (this.$route.name !== TREE_VIEW) return name;
-      return `${this.activity.id}: ${name}`;
+      const { activity, $route: { name: routeName } } = this;
+      const name = get(activity.data, 'name');
+      return (routeName === TREE_VIEW) ? `${activity.id}: ${name}` : name;
     }
   },
   methods: {

--- a/client/components/course/TreeView/TreeGraph.vue
+++ b/client/components/course/TreeView/TreeGraph.vue
@@ -127,7 +127,7 @@ export default {
       // Append label.
       node.append('text')
         .classed('label', true)
-        .text(d => d.data.name)
+        .text(d => d.data.name || d.data.id)
         .style('text-anchor', 'middle')
         .attr('dy', '.35em')
         .attr('y', d => {

--- a/client/components/course/TreeView/index.vue
+++ b/client/components/course/TreeView/index.vue
@@ -90,7 +90,6 @@ function tree(activities, structure, root = { size: 0 }, parent = root, depth = 
   parent.children = reduce(activities, (acc, it) => {
     const parentId = parent.id || null;
     if (it.parentId !== parentId) return acc;
-    it.name = it.id;
     it.color = getColor(it.type, structure);
     const subtree = tree(activities, structure, root, { ...it }, depth + 1);
     acc.push(subtree);


### PR DESCRIPTION
This resolves #149 .

When opening an activity deletion modal from the Outline, it will display the activity name only, but when opening the modal from the Tree view, it will display both the activity id and name (e.g. `Are you sure you want to delete activity 1051: Random Goal?`