### PR TITLE
Expand upper activity on outline only if new activity is its child

### DIFF
--- a/client/components/course/Outline/InsertActivity/index.vue
+++ b/client/components/course/Outline/InsertActivity/index.vue
@@ -88,7 +88,7 @@ export default {
       activity.parentId = this.resolveParent(activity);
       activity.position = this.calculatePosition(activity);
       this[this.action](activity);
-      if (this.anchor.type !== activity.type) this.$emit('expand');
+      if (this.anchor.id === activity.parentId) this.$emit('expand');
       this.hide();
     },
     isSameLevel(activity) {


### PR DESCRIPTION
This resolves #97 .

When adding a new activity on the outline below another activity, that upper activity will now expand only if the newly added activity is its child.