### PR TITLE
Generate `stats.json` inside root directory

### DIFF
--- a/build/plugins/stats.js
+++ b/build/plugins/stats.js
@@ -1,6 +1,8 @@
 'use strict';
 
-exports.name = 'clean-out-dir';
+const { writeFileSync } = require('fs');
+
+exports.name = 'stats';
 
 exports.cli = api => {
   api.command.option(
@@ -10,13 +12,25 @@ exports.cli = api => {
   );
 };
 
-exports.apply = (api, opts = {}) => {
-  const statsConfig = Object.assign({ fields: null }, opts);
+class StatsPlugin {
+  constructor({ logger, path = 'stats.json' } = {}) {
+    this.logger = logger;
+    this.path = path;
+  }
+
+  apply(compiler) {
+    compiler.hooks.done.tap('write-stats', stats => {
+      this.logger.log('\nGenerating webpack stats file');
+      writeFileSync(this.path, JSON.stringify(stats.toJson()), 'utf8');
+      this.logger.done(`Location: ${this.path}`);
+    });
+  }
+}
+
+exports.apply = api => {
   api.hook('createWebpackChain', config => {
     if (!api.cli.options.printStats) return;
-    const { StatsWriterPlugin } = require('webpack-stats-plugin');
-    config
-      .plugin('stats')
-      .use(StatsWriterPlugin, [statsConfig]);
+    const options = { logger: api.logger };
+    config.plugin('generate-stats').use(StatsPlugin, [options]);
   });
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -19903,12 +19903,6 @@
         "source-map": "~0.6.1"
       }
     },
-    "webpack-stats-plugin": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/webpack-stats-plugin/-/webpack-stats-plugin-0.2.1.tgz",
-      "integrity": "sha512-OYMZLpZrK/qLA79NE4kC4DCt85h/5ipvWJcsefKe9MMw0qU4/ck/IJg+4OmWA+5EfrZZpHXDq92IptfYDWVfkw==",
-      "dev": true
-    },
     "websocket-driver": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",

--- a/package.json
+++ b/package.json
@@ -166,8 +166,7 @@
     "stylelint-webpack-plugin": "^0.9.0",
     "umzug": "^2.2.0",
     "val-loader": "^1.1.1",
-    "vue-template-compiler": "^2.5.17",
-    "webpack-stats-plugin": "^0.2.1"
+    "vue-template-compiler": "^2.5.17"
   },
   "engines": {
     "node": ">= 8.8.0",


### PR DESCRIPTION
This PR alters behaviour of local poi stats plugin in order to generate stats inside _root_ dir instead of `dist`. This uses same approach as [`poi@9`](https://github.com/egoist/poi/blob/6d3c7ff/packages/poi/bin/run.js#L125-L134) :tada: