### PR TITLE
Remove the always showing scrollbar on an html element set by Vuetify

### DIFF
--- a/client/App.vue
+++ b/client/App.vue
@@ -34,6 +34,10 @@ html, body {
   height: 100%;
 }
 
+html {
+  overflow-y: auto !important; // override Vuetify's default style
+}
+
 #app {
   color: rgba(0,0,0,0.87);
   font-family: Roboto, Helvetica, Arial, sans-serif;


### PR DESCRIPTION
So apparently a part of the Vuetify's (questionable) design is to set
`overflow-y: scroll` on an `html` element, which makes the scrollbar
visible even when there is no overflowing content.
See this issue for more info: https://github.com/vuetifyjs/vuetify/issues/864

Note: Mac users probably don't notice this issue, because MacOS hides
the scrollbar by default if there's no mouse connected to it.