### PR TITLE
Create a content container by default, if one does't exist

### DIFF
--- a/client/components/editor/structure/ContentContainers/index.vue
+++ b/client/components/editor/structure/ContentContainers/index.vue
@@ -32,6 +32,7 @@ import capitalize from 'lodash/capitalize';
 import ContentContainer from './Container';
 import EventBus from 'EventBus';
 import get from 'lodash/get';
+import isEmpty from 'lodash/isEmpty';
 import { mapActions } from 'vuex-module';
 import maxBy from 'lodash/maxBy';
 
@@ -74,6 +75,9 @@ export default {
         action: () => this.remove(container)
       });
     }
+  },
+  created() {
+    if (isEmpty(this.containerGroup)) this.addContainer();
   },
   filters: {
     capitalize(val) {


### PR DESCRIPTION
Note: this only creates the content container when it's first opened;
it's still possible to delete all the content containers by hand and
then create the first one manually (which can be useful for users who
wish to drop their current work and start over).