### PR TITLE
Upgrade sequelize to v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1608,11 +1608,6 @@
       "resolved": "https://registry.npmjs.org/@snyk/gemfile/-/gemfile-1.2.0.tgz",
       "integrity": "sha512-nI7ELxukf7pT4/VraL4iabtNNMz8mUo7EXlqCFld8O5z6mIMLX9llps24iPpaIZOwArkY3FWA+4t+ixyvtTSIA=="
     },
-    "@types/geojson": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-1.0.6.tgz",
-      "integrity": "sha512-Xqg/lIZMrUd0VRmSRbCAewtwGZiAk3mEUDvV4op1tGl+LvyPcb/MIOSxTl9z+9+J+R4/vpjiCAT4xeKzH9ji1w=="
-    },
     "@types/node": {
       "version": "10.5.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.5.1.tgz",
@@ -2021,6 +2016,11 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
       "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk="
+    },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
     },
     "anymatch": {
       "version": "2.0.0",
@@ -5148,9 +5148,9 @@
       }
     },
     "dottie": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.0.tgz",
-      "integrity": "sha1-2hkZgci41xPKARXViYzzl8Lw3dA="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.1.tgz",
+      "integrity": "sha512-ch5OQgvGDK2u8pSZeSYAQaV/lczImd7pMJ7BcEPXmnFVjy4yJIzP6CsODJUTH8mg1tyH1Z2abOiuJO3DjZ/GBw=="
     },
     "dtrace-provider": {
       "version": "0.8.7",
@@ -9754,6 +9754,7 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.4.tgz",
       "integrity": "sha512-mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==",
       "dev": true,
+      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -9763,7 +9764,8 @@
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -9853,9 +9855,9 @@
       "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
     },
     "moment-timezone": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.21.tgz",
-      "integrity": "sha512-j96bAh4otsgj3lKydm3K7kdtA3iKf2m6MY2iSYCzCm5a1zmHo1g+aK3068dDEeocLZQIS9kU8bsdQHLqEvgW0A==",
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.23.tgz",
+      "integrity": "sha512-WHFH85DkCfiNMDX5D3X7hpNH3/PUhjTGcD0U1SgfBGZxJ3qUmJh5FdvaFjcClxOvB3rzdfj4oRffbI38jEnC1w==",
       "requires": {
         "moment": ">= 2.9.0"
       }
@@ -13299,12 +13301,11 @@
       "dev": true
     },
     "retry-as-promised": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-2.3.2.tgz",
-      "integrity": "sha1-zZdO5P2bX+A8vzGHHuSCIcB3N7c=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-3.2.0.tgz",
+      "integrity": "sha512-CybGs60B7oYU/qSQ6kuaFmRd9sTZ6oXSc0toqePvV74Ac6/IFZSI1ReFQmtCN+uvW1Mtqdwpvt/LGOiCBAY2Mg==",
       "requires": {
-        "bluebird": "^3.4.6",
-        "debug": "^2.6.9"
+        "any-promise": "^1.3.0"
       }
     },
     "rgb-regex": {
@@ -13621,51 +13622,49 @@
       }
     },
     "sequelize": {
-      "version": "4.38.0",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-4.38.0.tgz",
-      "integrity": "sha512-ZCcV2HuzU+03xunWgVeyXnPa/RYY5D2U/WUNpq+xF8VmDTLnSDsHl+pEwmiWrpZD7KdBqDczCeTgjToYyVzYQg==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-5.6.1.tgz",
+      "integrity": "sha512-QsXUDar6ow0HrF9BtnHRaNumu6qRYb97dfwvez/Z5guH3i6w6k8+bp6gP3VCiDC+2qX+jQIyrYohKg9evy8GFg==",
       "requires": {
         "bluebird": "^3.5.0",
         "cls-bluebird": "^2.1.0",
-        "debug": "^3.1.0",
-        "depd": "^1.1.0",
+        "debug": "^4.1.1",
         "dottie": "^2.0.0",
-        "generic-pool": "^3.4.0",
         "inflection": "1.12.0",
-        "lodash": "^4.17.1",
-        "moment": "^2.20.0",
-        "moment-timezone": "^0.5.14",
-        "retry-as-promised": "^2.3.2",
-        "semver": "^5.5.0",
-        "terraformer-wkt-parser": "^1.1.2",
+        "lodash": "^4.17.11",
+        "moment": "^2.24.0",
+        "moment-timezone": "^0.5.21",
+        "retry-as-promised": "^3.1.0",
+        "semver": "^5.6.0",
+        "sequelize-pool": "^1.0.2",
         "toposort-class": "^1.0.1",
         "uuid": "^3.2.1",
-        "validator": "^10.4.0",
-        "wkx": "^0.4.1"
+        "validator": "^10.11.0",
+        "wkx": "^0.4.6"
       },
       "dependencies": {
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
         },
-        "generic-pool": {
-          "version": "3.4.2",
-          "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.4.2.tgz",
-          "integrity": "sha512-H7cUpwCQSiJmAHM4c/aFu6fUfrhWXW1ncyh8ftxEPMu6AiYkHw9K8br720TGPZJbk5eOH2bynjZD1yPvdDAmag=="
+        "moment": {
+          "version": "2.24.0",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+          "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         },
         "semver": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
-        },
-        "uuid": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
         }
       }
     },
@@ -13858,6 +13857,21 @@
         }
       }
     },
+    "sequelize-pool": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-1.0.2.tgz",
+      "integrity": "sha512-VMKl/gCCdIvB1gFZ7p+oqLFEyZEz3oMMYjkKvfEC7GoO9bBcxmfOOU9RdkoltfXGgBZFigSChihRly2gKtsh2w==",
+      "requires": {
+        "bluebird": "^3.5.3"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.5.4",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
+          "integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw=="
+        }
+      }
+    },
     "serialize-javascript": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.6.1.tgz",
@@ -13990,9 +14004,9 @@
       }
     },
     "shimmer": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.0.tgz",
-      "integrity": "sha512-xTCx2vohXC2EWWDqY/zb4+5Mu28D+HYNSOuFzsyRDRvI/e1ICb69afwaUwfjr+25ZXldbOLyp+iDUZHq8UnTag=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
     "sigmund": {
       "version": "1.0.1",
@@ -15762,23 +15776,6 @@
         "execa": "^0.7.0"
       }
     },
-    "terraformer": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/terraformer/-/terraformer-1.0.9.tgz",
-      "integrity": "sha512-YlmQ1fsMWTkKGDGibCRWgmLzrpDRUr63Q025LJ/taYQ6j1Yb8q9McKF7NBi6ACAyUXO6F/bl9w6v4MY307y5Ag==",
-      "requires": {
-        "@types/geojson": "^1.0.0"
-      }
-    },
-    "terraformer-wkt-parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/terraformer-wkt-parser/-/terraformer-wkt-parser-1.2.0.tgz",
-      "integrity": "sha512-QU3iA54St5lF8Za1jg1oj4NYc8sn5tCZ08aNSWDeGzrsaV48eZk1iAVWasxhNspYBoCqdHuoot1pUTUrE1AJ4w==",
-      "requires": {
-        "@types/geojson": "^1.0.0",
-        "terraformer": "~1.0.5"
-      }
-    },
     "terser": {
       "version": "3.16.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-3.16.1.tgz",
@@ -16906,9 +16903,9 @@
       }
     },
     "validator": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-10.4.0.tgz",
-      "integrity": "sha512-Q/wBy3LB1uOyssgNlXSRmaf22NxjvDNZM2MtIQ4jaEOAB61xsh1TQxsq1CgzUMBV1lDrVMogIh8GjG1DYW0zLg=="
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
+      "integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw=="
     },
     "vary": {
       "version": "1.1.2",
@@ -17913,9 +17910,9 @@
       }
     },
     "wkx": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.4.5.tgz",
-      "integrity": "sha512-01dloEcJZAJabLO5XdcRgqdKpmnxS0zIT02LhkdWOZX2Zs2tPM6hlZ4XG9tWaWur1Qd1OO4kJxUbe2+5BofvnA==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.4.6.tgz",
+      "integrity": "sha512-LHxXlzRCYQXA9ZHgs8r7Gafh0gVOE8o3QmudM1PIkOdkXXjW7Thcl+gb2P2dRuKgW8cqkitCRZkkjtmWzpHi7A==",
       "requires": {
         "@types/node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "safe-require": "^1.0.3",
     "sass-web-fonts": "^2.0.2",
     "save-as": "^0.1.8",
-    "sequelize": "^4.22.0",
+    "sequelize": "^5.6.1",
     "snyk": "^1.134.2",
     "string-template": "^1.0.0",
     "to-case": "^2.0.0",

--- a/server/activity/activity.model.js
+++ b/server/activity/activity.model.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { getSiblingLevels } = require('../../config/shared/activities');
-const { Model } = require('sequelize');
+const { Model, Op } = require('sequelize');
 const calculatePosition = require('../shared/util/calculatePosition');
 const isEmpty = require('lodash/isEmpty');
 const map = require('lodash/map');
@@ -76,7 +76,7 @@ class Activity extends Model {
     });
   }
 
-  static scopes({ Op }) {
+  static scopes() {
     const notNull = { [Op.ne]: null };
     return {
       withReferences(relationships = []) {

--- a/server/activity/index.js
+++ b/server/activity/index.js
@@ -22,7 +22,7 @@ router
   .get('/courses/:courseId/activities/:activityId/publish', ctrl.publish);
 
 function getActivity(req, res) {
-  return Activity.findById(req.params.activityId, { paranoid: false })
+  return Activity.findByPk(req.params.activityId, { paranoid: false })
     .then(activity => activity || createError(NOT_FOUND, 'Activity not found'))
     .then(activity => {
       req.activity = activity;

--- a/server/comment/comment.model.js
+++ b/server/comment/comment.model.js
@@ -32,8 +32,8 @@ class Comment extends Model {
     };
   }
 
-  static addHooks(models) {
-    hooks.add(this, models);
+  static hooks(models, Hooks) {
+    hooks.add(this, models, Hooks);
   }
 
   static associate({ Activity, Course, User }) {

--- a/server/comment/hooks.js
+++ b/server/comment/hooks.js
@@ -18,8 +18,8 @@ function add(Comment) {
     broadcast(events.UPDATE, instance);
   });
 
-  addHooks(Comment, ['afterDelete'], (hook, instance) => {
-    Comment.findById(instance.id, { paranoid: false }).then(deleted => {
+  addHooks(Comment, ['afterDestroy'], (hook, instance) => {
+    Comment.findByPk(instance.id, { paranoid: false }).then(deleted => {
       broadcast(events.DELETE, deleted);
     });
   });

--- a/server/comment/hooks.js
+++ b/server/comment/hooks.js
@@ -1,26 +1,23 @@
 'use strict';
 
 const { broadcast, events } = require('./channel');
-const addHooks = require('../shared/util/addHooks');
 const pick = require('lodash/pick');
 
-module.exports = { add };
-
-function add(Comment) {
-  addHooks(Comment, ['afterCreate'], (hook, instance) => {
-    instance.getAuthor().then(a => {
+exports.add = (Comment, _, { HookTypes, addHook }) => {
+  addHook(Comment, HookTypes.afterCreate, (_, comment) => {
+    comment.getAuthor().then(a => {
       const author = pick(a, ['id', 'email']);
-      broadcast(events.CREATE, { ...instance.dataValues, author });
+      broadcast(events.CREATE, { ...comment.toJSON(), author });
     });
   });
 
-  addHooks(Comment, ['afterUpdate'], (hook, instance) => {
-    broadcast(events.UPDATE, instance);
+  addHook(Comment, HookTypes.afterUpdate, (_, comment) => {
+    broadcast(events.UPDATE, comment);
   });
 
-  addHooks(Comment, ['afterDestroy'], (hook, instance) => {
-    Comment.findByPk(instance.id, { paranoid: false }).then(deleted => {
+  addHook(Comment, HookTypes.afterDestroy, (_, comment) => {
+    Comment.findByPk(comment.id, { paranoid: false }).then(deleted => {
       broadcast(events.DELETE, deleted);
     });
   });
-}
+};

--- a/server/comment/index.js
+++ b/server/comment/index.js
@@ -32,7 +32,7 @@ router
 
 function getComment(req, res) {
   const include = [{ model: User, as: 'author', attributes: ['id', 'email'] }];
-  return Comment.findById(req.params.commentId, { paranoid: false, include })
+  return Comment.findByPk(req.params.commentId, { paranoid: false, include })
     .then(comment => comment || createError(NOT_FOUND, 'Comment not found'))
     .then(comment => {
       req.comment = comment;

--- a/server/course/course.controller.js
+++ b/server/course/course.controller.js
@@ -74,7 +74,7 @@ function upsertUser({ course, body }, res) {
 function removeUser(req, res) {
   const { course } = req;
   const { userId } = req.params;
-  return User.findById(userId)
+  return User.findByPk(userId)
     .then(user => user || createError(NOT_FOUND, 'User not found'))
     .then(user => course.removeUser(user))
     .then(() => res.end());

--- a/server/course/course.model.js
+++ b/server/course/course.model.js
@@ -81,7 +81,7 @@ class Course extends Model {
   }
 
   static updateStats(id, key, value) {
-    return this.findById(id).then(course => {
+    return this.findByPk(id).then(course => {
       if (!course) return;
       const stats = course.stats || {};
       stats[key] = value;

--- a/server/course/course.model.js
+++ b/server/course/course.model.js
@@ -76,8 +76,8 @@ class Course extends Model {
     };
   }
 
-  static addHooks(models) {
-    hooks.add(this, models);
+  static hooks(models, Hooks) {
+    hooks.add(this, models, Hooks);
   }
 
   static updateStats(id, key, value) {

--- a/server/course/hooks.js
+++ b/server/course/hooks.js
@@ -1,24 +1,28 @@
 'use strict';
 
 const { getObjectives, getSchemaId } = require('../../config/shared/activities');
-const addHooks = require('../shared/util/addHooks');
 const find = require('lodash/find');
 const first = require('lodash/first');
 const get = require('lodash/get');
 const logger = require('../shared/logger');
 const map = require('lodash/map');
 
-function add(Course, models) {
+exports.add = (Course, models, { HookTypes, addHooks }) => {
   const { Activity, TeachingElement } = models;
-  const hooks = ['afterCreate', 'afterBulkCreate', 'afterDestroy', 'afterBulkDestroy'];
+  const hooks = [
+    HookTypes.afterCreate,
+    HookTypes.afterBulkCreate,
+    HookTypes.afterDestroy,
+    HookTypes.afterBulkDestroy
+  ];
 
   // Track objectives.
-  addHooks(Activity, hooks, (hook, data, options) => {
+  addHooks(Activity, hooks, (hookType, data, options) => {
     const instance = Array.isArray(data) ? first(data) : data;
     const { id, courseId, type } = instance;
     const schemaId = getSchemaId(type);
     if (!schemaId) return;
-    logger.info(`[Course] Activity#${hook}`, { type, id, courseId });
+    logger.info(`[Course] Activity#${hookType}`, { type, id, courseId });
     const objectiveTypes = map(getObjectives(schemaId), 'type');
     const where = { courseId, type: objectiveTypes, detached: false };
     return Activity.count({ where })
@@ -26,17 +30,15 @@ function add(Course, models) {
   });
 
   // Track assessments.
-  addHooks(TeachingElement, hooks, (hook, data, { context }) => {
+  addHooks(TeachingElement, hooks, (hookType, data, { context }) => {
     const instance = Array.isArray(data)
       ? find(data, { type: 'ASSESSMENT' })
       : data;
     if (get(instance, 'type') !== 'ASSESSMENT') return;
     const { id, courseId, type } = instance;
-    logger.info(`[Course] TeachingElement#${hook}`, { type, id, courseId });
+    logger.info(`[Course] TeachingElement#${hookType}`, { type, id, courseId });
     const where = { courseId, type: 'ASSESSMENT', detached: false };
     return TeachingElement.count({ where })
       .then(count => Course.updateStats(courseId, 'assessments', count));
   });
-}
-
-module.exports = { add };
+};

--- a/server/course/index.js
+++ b/server/course/index.js
@@ -24,7 +24,7 @@ router
   .get('/courses/:id/contentInventory', ctrl.exportContentInventory);
 
 function getCourse(req, res) {
-  return Course.findById(req.params.id, { paranoid: false })
+  return Course.findByPk(req.params.id, { paranoid: false })
     .then(course => course || createError(NOT_FOUND, 'Course not found'))
     .then(course => {
       req.course = course;

--- a/server/revision/hooks.js
+++ b/server/revision/hooks.js
@@ -1,24 +1,23 @@
 'use strict';
 
-const addHooks = require('../shared/util/addHooks');
 const { constant } = require('to-case');
 const logger = require('../shared/logger');
 
 module.exports = { add };
 
-function add(Revision, models) {
+function add(Revision, models, { HookTypes, addHooks }) {
   const { Course, Activity, TeachingElement } = models;
   const hooksDict = {
-    afterCreate: 'CREATE',
-    afterUpdate: 'UPDATE',
-    afterDestroy: 'REMOVE'
+    [HookTypes.afterCreate]: 'CREATE',
+    [HookTypes.afterUpdate]: 'UPDATE',
+    [HookTypes.afterDestroy]: 'REMOVE'
   };
   const hooks = Object.keys(hooksDict);
 
   // TODO: Courses are soft deleted already?
   // When course is removed, its id is no longer valid and cannot be saved
   // as a foreign key. Remove this when courses are soft-deleted:
-  addHooks(Course, ['afterCreate', 'afterUpdate'], createRevision);
+  addHooks(Course, [HookTypes.afterCreate, HookTypes.afterUpdate], createRevision);
 
   addHooks(Activity, hooks, createRevision);
   addHooks(TeachingElement, hooks, createRevision);

--- a/server/revision/hooks.js
+++ b/server/revision/hooks.js
@@ -1,36 +1,36 @@
 'use strict';
 
 const { constant } = require('to-case');
+const forEach = require('lodash/forEach');
 const logger = require('../shared/logger');
 
 module.exports = { add };
 
-function add(Revision, models, { HookTypes, addHooks }) {
+function add(Revision, models, { HookTypes, addHook }) {
   const { Course, Activity, TeachingElement } = models;
-  const hooksDict = {
+  const hooks = {
     [HookTypes.afterCreate]: 'CREATE',
     [HookTypes.afterUpdate]: 'UPDATE',
     [HookTypes.afterDestroy]: 'REMOVE'
   };
-  const hooks = Object.keys(hooksDict);
+  const isCourse = model => model instanceof Course;
 
   // TODO: Courses are soft deleted already?
   // When course is removed, its id is no longer valid and cannot be saved
   // as a foreign key. Remove this when courses are soft-deleted:
-  addHooks(Course, [HookTypes.afterCreate, HookTypes.afterUpdate], createRevision);
+  addHook(Course, HookTypes.afterCreate, createRevision);
+  addHook(Course, HookTypes.afterUpdate, createRevision);
 
-  addHooks(Activity, hooks, createRevision);
-  addHooks(TeachingElement, hooks, createRevision);
+  forEach(hooks, (_, type) => addHook(Activity, type, createRevision));
+  forEach(hooks, (_, type) => addHook(TeachingElement, type, createRevision));
 
-  function createRevision(hook, instance, { context, transaction }) {
-    if (!context || !context.userId) return;
-    const Model = instance.constructor;
-    const courseId = Model.name === Course.name ? instance.id : instance.courseId;
-    const entity = constant(Model.name);
-    const operation = hooksDict[hook];
-    const state = instance.get({ plain: true });
-    logger.info(`[Revision] ${entity}#${hook}`, { entity, operation, id: instance.id, courseId });
-    const revision = { courseId, entity, operation, state, userId: context.userId };
+  function createRevision(hookType, instance, { context = {}, transaction }) {
+    if (!context.userId) return;
+    const courseId = isCourse(instance) ? instance.id : instance.courseId;
+    const entity = constant(instance.constructor.name);
+    const operation = hooks[hookType];
+    logger.info(`[Revision] ${entity}#${hookType}`, { entity, operation, id: instance.id, courseId });
+    const revision = { courseId, entity, operation, state: instance.toJSON(), userId: context.userId };
     return Revision.create(revision, { transaction });
   }
 }

--- a/server/revision/index.js
+++ b/server/revision/index.js
@@ -12,7 +12,7 @@ router.get('/courses/:id/revisions/:revisionId', ctrl.resolve);
 
 function getRevision(req, res) {
   const include = [{ model: User, attributes: ['id', 'email'] }];
-  return Revision.findById(req.params.revisionId, { include })
+  return Revision.findByPk(req.params.revisionId, { include })
     .then(revision => revision || createError(NOT_FOUND, 'Revision not found'))
     .then(revision => {
       req.revision = revision;

--- a/server/revision/revision.model.js
+++ b/server/revision/revision.model.js
@@ -49,8 +49,8 @@ class Revision extends Model {
     };
   }
 
-  static addHooks(models) {
-    hooks.add(this, models);
+  static hooks(models, Hooks) {
+    hooks.add(this, models, Hooks);
   }
 }
 

--- a/server/shared/auth/index.js
+++ b/server/shared/auth/index.js
@@ -12,7 +12,7 @@ const jwtOptions = {
 };
 
 passport.use(new Strategy(jwtOptions, (payload, done) => {
-  return User.findById(payload.id)
+  return User.findByPk(payload.id)
     .then(user => done(null, user || false))
     .error(err => done(err, false));
 }));

--- a/server/shared/database/hooks.js
+++ b/server/shared/database/hooks.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const { hooks } = require('sequelize/lib/hooks');
+const mapValues = require('lodash/mapValues');
+
+const HookTypes = mapValues(hooks, (_, key) => key);
+
+const isFunction = arg => typeof arg === 'function';
+const noop = () => {};
+
+exports.HookTypes = HookTypes;
+
+exports.addHook = (Model, hookType, name, hook) => {
+  checkType(hookType);
+  if (isFunction(name)) {
+    hook = name;
+    name = null;
+  }
+  Model.addHook(hookType, name, function (...args) {
+    return hook.call(this, hookType, ...args);
+  });
+};
+
+exports.addHooks = (Model, hookTypes = [], hook = noop) => {
+  hookTypes.forEach(it => exports.addHook(Model, it, hook));
+};
+
+exports.removeHook = (Model, hookType, name) => {
+  checkType(hookType);
+  return Model.removeHook(hookType, name);
+};
+
+exports.hasHook = (Model, hookType) => {
+  checkType(hookType);
+  return Model.hasHook(hookType, name);
+};
+
+function checkType(hookType) {
+  if (!(hookType in HookTypes)) {
+    throw new TypeError(`Invalid hook type: ${hookType}`);
+  }
+}

--- a/server/shared/database/hooks.js
+++ b/server/shared/database/hooks.js
@@ -16,18 +16,21 @@ exports.addHook = (Model, hookType, name, hook) => {
     hook = name;
     name = null;
   }
-  Model.addHook(hookType, name, function (...args) {
+  Model.addHook(hookType, name, wrappedHook);
+  return wrappedHook;
+
+  function wrappedHook(...args) {
     return hook.call(this, hookType, ...args);
-  });
+  }
 };
 
 exports.addHooks = (Model, hookTypes = [], hook = noop) => {
-  hookTypes.forEach(it => exports.addHook(Model, it, hook));
+  return hookTypes.map(it => exports.addHook(Model, it, hook));
 };
 
 exports.removeHook = (Model, hookType, name) => {
   checkType(hookType);
-  return Model.removeHook(hookType, name);
+  Model.removeHook(hookType, name);
 };
 
 exports.hasHook = (Model, hookType) => {

--- a/server/shared/database/index.js
+++ b/server/shared/database/index.js
@@ -28,10 +28,9 @@ const { Sequelize: { DataTypes } } = sequelize;
 const defineModel = Model => {
   const fields = invoke(Model, 'fields', DataTypes, sequelize) || {};
   const hooks = invoke(Model, 'hooks') || {};
-  const scopes = invoke(Model, 'scopes', sequelize) || {};
   const options = invoke(Model, 'options') || {};
   wrapAsyncMethods(Model);
-  return Model.init(fields, { sequelize, hooks, scopes, ...options });
+  return Model.init(fields, { sequelize, hooks, ...options });
 };
 
 function initialize() {
@@ -85,6 +84,9 @@ const models = {
 forEach(models, model => {
   invoke(model, 'associate', models);
   invoke(model, 'addHooks', models);
+  const scopes = invoke(model, 'scopes', models);
+  if (!scopes) return;
+  forEach(scopes, (it, name) => model.addScope(name, it, { override: true }));
 });
 
 const db = {

--- a/server/shared/database/index.js
+++ b/server/shared/database/index.js
@@ -4,6 +4,7 @@ const { migrationsPath } = require('../../../sequelize.config');
 const { wrapAsyncMethods } = require('./helpers');
 const config = require('./config');
 const forEach = require('lodash/forEach');
+const Hooks = require('./hooks');
 const invoke = require('lodash/invoke');
 const logger = require('../logger');
 const pick = require('lodash/pick');
@@ -27,10 +28,9 @@ const { Sequelize: { DataTypes } } = sequelize;
 
 const defineModel = Model => {
   const fields = invoke(Model, 'fields', DataTypes, sequelize) || {};
-  const hooks = invoke(Model, 'hooks') || {};
   const options = invoke(Model, 'options') || {};
   wrapAsyncMethods(Model);
-  return Model.init(fields, { sequelize, hooks, ...options });
+  return Model.init(fields, { sequelize, ...options });
 };
 
 function initialize() {
@@ -83,7 +83,7 @@ const models = {
 
 forEach(models, model => {
   invoke(model, 'associate', models);
-  invoke(model, 'addHooks', models);
+  invoke(model, 'hooks', models, Hooks);
   const scopes = invoke(model, 'scopes', models);
   if (!scopes) return;
   forEach(scopes, (it, name) => model.addScope(name, it, { override: true }));

--- a/server/shared/util/addHooks.js
+++ b/server/shared/util/addHooks.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = function addHooks(Model, hooks, fn) {
-  hooks.forEach(hook => Model.hook(hook, function (instance, options) {
+  hooks.forEach(hook => Model.addHook(hook, function (instance, options) {
     return fn.call(this, hook, instance, options);
   }));
 };

--- a/server/shared/util/addHooks.js
+++ b/server/shared/util/addHooks.js
@@ -1,7 +1,0 @@
-'use strict';
-
-module.exports = function addHooks(Model, hooks, fn) {
-  hooks.forEach(hook => Model.addHook(hook, function (instance, options) {
-    return fn.call(this, hook, instance, options);
-  }));
-};

--- a/server/shared/util/processListQuery.js
+++ b/server/shared/util/processListQuery.js
@@ -2,6 +2,7 @@
 
 const assign = require('lodash/assign');
 const defaultsDeep = require('lodash/defaultsDeep');
+const { Op } = require('sequelize');
 const pick = require('lodash/pick');
 
 const filter = {
@@ -22,7 +23,7 @@ module.exports = function (defaults) {
 
     if (query.syncedAt) {
       const condition = { $gte: query.syncedAt };
-      options.where.$or = [{ updatedAt: condition }, { deletedAt: condition }];
+      options.where[Op.or] = [{ updatedAt: condition }, { deletedAt: condition }];
     }
 
     req.opts = options;

--- a/server/teaching-element/te.controller.js
+++ b/server/teaching-element/te.controller.js
@@ -3,10 +3,10 @@
 const { Activity, TeachingElement, Sequelize } = require('../shared/database');
 const { createError } = require('../shared/error/helpers');
 const { NOT_FOUND } = require('http-status-codes');
+const { Op } = require('sequelize');
 const { resolveStatics } = require('../shared/storage/helpers');
 const pick = require('lodash/pick');
 
-const { Op } = Sequelize;
 
 function list({ course, query, opts }, res) {
   if (query.activityId || query.parentId) {

--- a/server/teaching-element/te.controller.js
+++ b/server/teaching-element/te.controller.js
@@ -43,7 +43,7 @@ function patch({ body, params, user }, res) {
   const attrs = ['refs', 'type', 'data', 'meta', 'position', 'courseId', 'deletedAt'];
   const data = pick(body, attrs);
   const paranoid = body.paranoid !== false;
-  return TeachingElement.findById(params.teId, { paranoid })
+  return TeachingElement.findByPk(params.teId, { paranoid })
     .then(asset => asset || createError(NOT_FOUND, 'TEL not found'))
     .then(asset => asset.update(data, { context: { userId: user.id } }))
     .then(asset => resolveStatics(asset))
@@ -51,14 +51,14 @@ function patch({ body, params, user }, res) {
 }
 
 function remove({ params, user }, res) {
-  return TeachingElement.findById(params.teId)
+  return TeachingElement.findByPk(params.teId)
     .then(asset => asset || createError(NOT_FOUND, 'TEL not found'))
     .then(asset => asset.destroy({ context: { userId: user.id } }))
     .then(() => res.end());
 }
 
 function reorder({ body, params }, res) {
-  return TeachingElement.findById(params.teId)
+  return TeachingElement.findByPk(params.teId)
     .then(asset => asset.reorder(body.position))
     .then(asset => res.json({ data: asset }));
 }

--- a/server/teaching-element/te.model.js
+++ b/server/teaching-element/te.model.js
@@ -5,7 +5,7 @@ const forEach = require('lodash/forEach');
 const get = require('lodash/get');
 const hash = require('hash-obj');
 const isNumber = require('lodash/isNumber');
-const { Model } = require('sequelize');
+const { Model, Op } = require('sequelize');
 const pick = require('lodash/pick');
 const { processStatics, resolveStatics } = require('../shared/storage/helpers');
 
@@ -101,7 +101,7 @@ class TeachingElement extends Model {
     };
   }
 
-  static scopes({ Op }) {
+  static scopes() {
     const notNull = { [Op.ne]: null };
     return {
       withReferences: { where: { 'refs.objectiveId': notNull } }
@@ -120,7 +120,7 @@ class TeachingElement extends Model {
 
   static fetch(opt) {
     return isNumber(opt)
-      ? TeachingElement.findById(opt).then(it => it && resolveStatics(it))
+      ? TeachingElement.findByPk(opt).then(it => it && resolveStatics(it))
       : TeachingElement.findAll(opt)
           .then(arr => Promise.all(arr.map(it => resolveStatics(it))));
   }

--- a/server/user/user.controller.js
+++ b/server/user/user.controller.js
@@ -12,7 +12,7 @@ function index(req, res) {
 
 function forgotPassword({ body }, res) {
   const { email } = body;
-  return User.find({ where: { email } })
+  return User.findOne({ where: { email } })
     .then(user => user || createError(NOT_FOUND, 'User not found'))
     .then(user => user.sendResetToken())
     .then(() => res.end());
@@ -20,7 +20,7 @@ function forgotPassword({ body }, res) {
 
 function resetPassword({ body, params }, res) {
   const { password, token } = body;
-  return User.find({ where: { token } })
+  return User.findOne({ where: { token } })
     .then(user => user || createError(NOT_FOUND, 'Invalid token'))
     .then(user => {
       user.password = password;
@@ -34,7 +34,7 @@ function login({ body }, res) {
   if (!email || !password) {
     createError(400, 'Please enter email and password');
   }
-  return User.find({ where: { email } })
+  return User.findOne({ where: { email } })
     .then(user => user || createError(NOT_FOUND, 'User does not exist'))
     .then(user => user.authenticate(password))
     .then(user => user || createError(NOT_FOUND, 'Wrong password'))


### PR DESCRIPTION
This PR upgrades [`sequelize`](https://npm.im/sequelize) to v5 and introduces changes to `scopes` and `hooks` handling :tada: