### PR TITLE
Ignore filesystem provider storage area

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,7 +39,7 @@ EMAIL_HOST=email-smtp.us-east-1.amazonaws.com
 STORAGE_PROVIDER=filesystem
 
 # Filesystem provider settings
-STORAGE_PATH=
+STORAGE_PATH=data
 
 # Amazon provider settings
 STORAGE_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,10 @@ client/assets/img/*favicon*
 # DB migrations
 umzug.json
 
+# Filesystem storage provider
+data/*
+!data/.gitkeep
+
 # Build artifacts
 dist/*
 !dist/.gitkeep


### PR DESCRIPTION
This PR sets default filesystem storage provider output area to `./data` directory which has been included in `.gitignore`.