### PR TITLE
Fix postgres version check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10555,6 +10555,13 @@
         "is-builtin-module": "^1.0.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+        }
       }
     },
     "normalize-path": {
@@ -11282,6 +11289,13 @@
         "pg-types": "1.*",
         "pgpass": "1.*",
         "semver": "4.3.2"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
+          "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c="
+        }
       }
     },
     "pg-connection-string": {
@@ -13575,9 +13589,9 @@
       }
     },
     "semver": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
-      "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
+      "integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ=="
     },
     "semver-diff": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "safe-require": "^1.0.3",
     "sass-web-fonts": "^2.0.2",
     "save-as": "^0.1.8",
+    "semver": "^6.0.0",
     "sequelize": "^5.6.1",
     "snyk": "^1.134.2",
     "string-template": "^1.0.0",
@@ -175,6 +176,7 @@
   },
   "engines": {
     "node": ">= 8.8.0",
-    "npm": ">= 5.4.2"
+    "npm": ">= 5.4.2",
+    "postgres": ">= 9.4"
   }
 }

--- a/server/shared/database/index.js
+++ b/server/shared/database/index.js
@@ -130,15 +130,13 @@ function getConfig(sequelize) {
 }
 
 function checkPostgreVersion(sequelize) {
-  const type = sequelize.QueryTypes.VERSION;
-  return sequelize.query('SHOW server_version', { type })
-    .then(version => {
-      logger.info({ version }, 'PostgreSQL version:', version);
-      const range = pkg.engines && pkg.engines.postgres;
-      if (!range) return;
-      if (semver.satisfies(semver.coerce(version), range)) return;
-      const err = new Error(`"${pkg.name}" requires PostgreSQL ${range}`);
-      logger.error({ version, required: range }, err.message);
-      return Promise.reject(err);
-    });
+  return sequelize.getQueryInterface().databaseVersion().then(version => {
+    logger.info({ version }, 'PostgreSQL version:', version);
+    const range = pkg.engines && pkg.engines.postgres;
+    if (!range) return;
+    if (semver.satisfies(semver.coerce(version), range)) return;
+    const err = new Error(`"${pkg.name}" requires PostgreSQL ${range}`);
+    logger.error({ version, required: range }, err.message);
+    return Promise.reject(err);
+  });
 }


### PR DESCRIPTION
This PR fixes postegres version checking by adding version constraint to `package.json` `engines` map and adding missing `semver` dependency. :bug: