### PR TITLE
Extend InputAsset component to accept additional prop

### DIFF
--- a/client/components/common/InputAsset.vue
+++ b/client/components/common/InputAsset.vue
@@ -11,6 +11,7 @@
       <v-icon>mdi-open-in-new</v-icon>
     </v-btn>
     <file-upload
+      v-if="allowFileUpload"
       v-show="!file && isEditing"
       :uploading.sync="uploading"
       :validate="{ ext: extensions }"
@@ -34,7 +35,7 @@
       v-if="!uploading && (urlInput || !hasAsset)"
       v-model="urlInput"
       :disabled="!isEditing"
-      placeholder="or paste a URL"/>
+      :placeholder="allowFileUpload ? 'or paste a URL' : 'Paste a URL'"/>
     <span class="actions">
       <v-btn
         v-if="!isEditing"
@@ -73,7 +74,8 @@ export default {
     url: { type: String, default: null },
     publicUrl: { type: String, default: null },
     extensions: { type: Array, required: true },
-    uploadLabel: { type: String, default: 'Select file' }
+    uploadLabel: { type: String, default: 'Select file' },
+    allowFileUpload: { type: Boolean, default: true }
   },
   data() {
     const isLinked = !isUploaded(this.url);

--- a/client/components/common/InputAsset.vue
+++ b/client/components/common/InputAsset.vue
@@ -74,8 +74,8 @@ export default {
     url: { type: String, default: null },
     publicUrl: { type: String, default: null },
     extensions: { type: Array, required: true },
-    uploadLabel: { type: String, default: 'Select file' },
-    allowFileUpload: { type: Boolean, default: true }
+    allowFileUpload: { type: Boolean, default: true },
+    uploadLabel: { type: String, default: 'Select file' }
   },
   data() {
     const isLinked = !isUploaded(this.url);


### PR DESCRIPTION
`InputAssets` component is now extended with `allowFileUpload` prop to determine if `file-upload` component should be rendered. Additionally, placeholder text for URL input field is changed depending on the prop. `allowFileUpload` defaults to `true` to preserve current behaviour.