### PR TITLE
Logger modification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,9 @@ ENABLE_DEFAULT_SCHEMA=1
 # repositoryId and activityId.
 PREVIEW_URL=https://myserver.com/repository/{repositoryId}/activity/{activityId}
 
+# Logger
+LOG_LEVEL='info'
+
 # Terminal (forcefully enable color)
 FORCE_COLOR=1
 

--- a/server/shared/logger.js
+++ b/server/shared/logger.js
@@ -2,10 +2,15 @@
 
 const bunyan = require('bunyan');
 
+const logLevel = (() => {
+  if (process.env.LOG_LEVEL) return process.env.LOG_LEVEL;
+  return process.env.NODE_ENV === 'production' ? 'info' : 'debug';
+})();
+
 const logger = bunyan.createLogger({
   name: 'tailor-server',
   serializers: bunyan.stdSerializers,
-  level: process.env.LOG_LEVEL
+  level: logLevel
 });
 
 module.exports = logger;

--- a/server/shared/logger.js
+++ b/server/shared/logger.js
@@ -4,7 +4,8 @@ const bunyan = require('bunyan');
 
 const logger = bunyan.createLogger({
   name: 'tailor-server',
-  serializers: bunyan.stdSerializers
+  serializers: bunyan.stdSerializers,
+  level: process.env.LOG_LEVEL
 });
 
 module.exports = logger;


### PR DESCRIPTION
This PR provides developer to set [bunyan](https://www.npmjs.com/package/bunyan#levels) logger `level`. Suggestion is to set level type `'debug'`. Reason for that is, for example: when developer is querying database, it will display query logs in terminal which can be very helpful.