### PR TITLE
Reformat migration files

### DIFF
--- a/server/shared/database/migrations/20181115140901-create-user.js
+++ b/server/shared/database/migrations/20181115140901-create-user.js
@@ -2,41 +2,40 @@
 
 const TABLE_NAME = 'user';
 
-module.exports = {
-  up: (queryInterface, Sequelize) => queryInterface.createTable(TABLE_NAME, {
-    id: {
-      type: Sequelize.INTEGER,
-      primaryKey: true,
-      autoIncrement: true
-    },
-    email: {
-      type: Sequelize.STRING,
-      unique: true
-    },
-    password: {
-      type: Sequelize.STRING
-    },
-    role: {
-      type: Sequelize.ENUM('ADMIN', 'USER', 'INTEGRATION')
-    },
-    token: {
-      type: Sequelize.STRING,
-      unique: true
-    },
-    createdAt: {
-      type: Sequelize.DATE,
-      field: 'created_at',
-      allowNull: false
-    },
-    updatedAt: {
-      type: Sequelize.DATE,
-      field: 'updated_at',
-      allowNull: false
-    },
-    deletedAt: {
-      type: Sequelize.DATE,
-      field: 'deleted_at'
-    }
-  }),
-  down: queryInterface => queryInterface.dropTable(TABLE_NAME)
-};
+exports.up = (queryInterface, Sequelize) => queryInterface.createTable(TABLE_NAME, {
+  id: {
+    type: Sequelize.INTEGER,
+    primaryKey: true,
+    autoIncrement: true
+  },
+  email: {
+    type: Sequelize.STRING,
+    unique: true
+  },
+  password: {
+    type: Sequelize.STRING
+  },
+  role: {
+    type: Sequelize.ENUM('ADMIN', 'USER', 'INTEGRATION')
+  },
+  token: {
+    type: Sequelize.STRING,
+    unique: true
+  },
+  createdAt: {
+    type: Sequelize.DATE,
+    field: 'created_at',
+    allowNull: false
+  },
+  updatedAt: {
+    type: Sequelize.DATE,
+    field: 'updated_at',
+    allowNull: false
+  },
+  deletedAt: {
+    type: Sequelize.DATE,
+    field: 'deleted_at'
+  }
+});
+
+exports.down = queryInterface => queryInterface.dropTable(TABLE_NAME);

--- a/server/shared/database/migrations/20181115140902-create-course.js
+++ b/server/shared/database/migrations/20181115140902-create-course.js
@@ -2,49 +2,48 @@
 
 const TABLE_NAME = 'course';
 
-module.exports = {
-  up: (queryInterface, Sequelize) => queryInterface.createTable(TABLE_NAME, {
-    id: {
-      type: Sequelize.INTEGER,
-      primaryKey: true,
-      autoIncrement: true
-    },
-    uid: {
-      type: Sequelize.UUID,
-      unique: true,
-      defaultValue: Sequelize.UUIDV4
-    },
-    schema: {
-      type: Sequelize.STRING
-    },
-    name: {
-      type: Sequelize.STRING
-    },
-    description: {
-      type: Sequelize.TEXT
-    },
-    data: {
-      type: Sequelize.JSONB,
-      defaultValue: {}
-    },
-    stats: {
-      type: Sequelize.JSONB,
-      defaultValue: { objectives: 0, assessments: 0 }
-    },
-    createdAt: {
-      type: Sequelize.DATE,
-      field: 'created_at',
-      allowNull: false
-    },
-    updatedAt: {
-      type: Sequelize.DATE,
-      field: 'updated_at',
-      allowNull: false
-    },
-    deletedAt: {
-      type: Sequelize.DATE,
-      field: 'deleted_at'
-    }
-  }),
-  down: queryInterface => queryInterface.dropTable(TABLE_NAME)
-};
+exports.up = (queryInterface, Sequelize) => queryInterface.createTable(TABLE_NAME, {
+  id: {
+    type: Sequelize.INTEGER,
+    primaryKey: true,
+    autoIncrement: true
+  },
+  uid: {
+    type: Sequelize.UUID,
+    unique: true,
+    defaultValue: Sequelize.UUIDV4
+  },
+  schema: {
+    type: Sequelize.STRING
+  },
+  name: {
+    type: Sequelize.STRING
+  },
+  description: {
+    type: Sequelize.TEXT
+  },
+  data: {
+    type: Sequelize.JSONB,
+    defaultValue: {}
+  },
+  stats: {
+    type: Sequelize.JSONB,
+    defaultValue: { objectives: 0, assessments: 0 }
+  },
+  createdAt: {
+    type: Sequelize.DATE,
+    field: 'created_at',
+    allowNull: false
+  },
+  updatedAt: {
+    type: Sequelize.DATE,
+    field: 'updated_at',
+    allowNull: false
+  },
+  deletedAt: {
+    type: Sequelize.DATE,
+    field: 'deleted_at'
+  }
+});
+
+exports.down = queryInterface => queryInterface.dropTable(TABLE_NAME);

--- a/server/shared/database/migrations/20181115140903-course-user-relationship.js
+++ b/server/shared/database/migrations/20181115140903-course-user-relationship.js
@@ -2,47 +2,46 @@
 
 const TABLE_NAME = 'course_user';
 
-module.exports = {
-  up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable(TABLE_NAME, {
-      userId: {
-        type: Sequelize.INTEGER,
-        field: 'user_id',
-        references: { model: 'user', key: 'id' },
-        allowNull: false
-      },
-      courseId: {
-        type: Sequelize.INTEGER,
-        field: 'course_id',
-        references: { model: 'course', key: 'id' },
-        allowNull: false
-      },
-      role: {
-        type: Sequelize.ENUM('COURSE_ADMIN', 'COURSE_AUTHOR')
-      },
-      createdAt: {
-        type: Sequelize.DATE,
-        field: 'created_at',
-        allowNull: false
-      },
-      updatedAt: {
-        type: Sequelize.DATE,
-        field: 'updated_at',
-        allowNull: false
-      },
-      deletedAt: {
-        type: Sequelize.DATE,
-        field: 'deleted_at'
-      }
-    }).then(async () => {
-      const table = await queryInterface.describeTable(TABLE_NAME);
-      if (table.course_id.primaryKey && table.user_id.primaryKey) return;
-      return queryInterface.addConstraint(
-        TABLE_NAME,
-        ['course_id', 'user_id'],
-        { type: 'primary key', name: 'course_user_pkey' }
-      );
-    });
-  },
-  down: queryInterface => queryInterface.dropTable(TABLE_NAME)
+exports.up = (queryInterface, Sequelize) => {
+  return queryInterface.createTable(TABLE_NAME, {
+    userId: {
+      type: Sequelize.INTEGER,
+      references: { model: 'user', key: 'id' },
+      field: 'user_id',
+      allowNull: false
+    },
+    courseId: {
+      type: Sequelize.INTEGER,
+      field: 'course_id',
+      references: { model: 'course', key: 'id' },
+      allowNull: false
+    },
+    role: {
+      type: Sequelize.ENUM('COURSE_ADMIN', 'COURSE_AUTHOR')
+    },
+    createdAt: {
+      type: Sequelize.DATE,
+      field: 'created_at',
+      allowNull: false
+    },
+    updatedAt: {
+      type: Sequelize.DATE,
+      field: 'updated_at',
+      allowNull: false
+    },
+    deletedAt: {
+      type: Sequelize.DATE,
+      field: 'deleted_at'
+    }
+  }).then(async () => {
+    const table = await queryInterface.describeTable(TABLE_NAME);
+    if (table.course_id.primaryKey && table.user_id.primaryKey) return;
+    return queryInterface.addConstraint(
+      TABLE_NAME,
+      ['course_id', 'user_id'],
+      { type: 'primary key', name: 'course_user_pkey' }
+    );
+  });
 };
+
+exports.down = queryInterface => queryInterface.dropTable(TABLE_NAME);

--- a/server/shared/database/migrations/20181115140904-create-activity.js
+++ b/server/shared/database/migrations/20181115140904-create-activity.js
@@ -2,66 +2,65 @@
 
 const TABLE_NAME = 'activity';
 
-module.exports = {
-  up: (queryInterface, Sequelize) => queryInterface.createTable(TABLE_NAME, {
-    id: {
-      type: Sequelize.INTEGER,
-      primaryKey: true,
-      autoIncrement: true
-    },
-    courseId: {
-      type: Sequelize.INTEGER,
-      field: 'course_id',
-      references: { model: 'course', key: 'id' }
-    },
-    parentId: {
-      type: Sequelize.INTEGER,
-      field: 'parent_id',
-      references: { model: 'activity', key: 'id' }
-    },
-    uid: {
-      type: Sequelize.UUID,
-      unique: true,
-      defaultValue: Sequelize.UUIDV4
-    },
-    type: {
-      type: Sequelize.STRING
-    },
-    position: {
-      type: Sequelize.DOUBLE,
-      allowNull: false
-    },
-    data: {
-      type: Sequelize.JSONB,
-      defaultValue: {}
-    },
-    refs: {
-      type: Sequelize.JSONB,
-      defaultValue: {}
-    },
-    detached: {
-      type: Sequelize.BOOLEAN,
-      defaultValue: false,
-      allowNull: false
-    },
-    publishedAt: {
-      type: Sequelize.DATE,
-      field: 'published_at'
-    },
-    createdAt: {
-      type: Sequelize.DATE,
-      field: 'created_at',
-      allowNull: false
-    },
-    updatedAt: {
-      type: Sequelize.DATE,
-      field: 'updated_at',
-      allowNull: false
-    },
-    deletedAt: {
-      type: Sequelize.DATE,
-      field: 'deleted_at'
-    }
-  }),
-  down: queryInterface => queryInterface.dropTable(TABLE_NAME)
-};
+exports.up = (queryInterface, Sequelize) => queryInterface.createTable(TABLE_NAME, {
+  id: {
+    type: Sequelize.INTEGER,
+    primaryKey: true,
+    autoIncrement: true
+  },
+  courseId: {
+    type: Sequelize.INTEGER,
+    field: 'course_id',
+    references: { model: 'course', key: 'id' }
+  },
+  parentId: {
+    type: Sequelize.INTEGER,
+    field: 'parent_id',
+    references: { model: 'activity', key: 'id' }
+  },
+  uid: {
+    type: Sequelize.UUID,
+    unique: true,
+    defaultValue: Sequelize.UUIDV4
+  },
+  type: {
+    type: Sequelize.STRING
+  },
+  position: {
+    type: Sequelize.DOUBLE,
+    allowNull: false
+  },
+  data: {
+    type: Sequelize.JSONB,
+    defaultValue: {}
+  },
+  refs: {
+    type: Sequelize.JSONB,
+    defaultValue: {}
+  },
+  detached: {
+    type: Sequelize.BOOLEAN,
+    defaultValue: false,
+    allowNull: false
+  },
+  publishedAt: {
+    type: Sequelize.DATE,
+    field: 'published_at'
+  },
+  createdAt: {
+    type: Sequelize.DATE,
+    field: 'created_at',
+    allowNull: false
+  },
+  updatedAt: {
+    type: Sequelize.DATE,
+    field: 'updated_at',
+    allowNull: false
+  },
+  deletedAt: {
+    type: Sequelize.DATE,
+    field: 'deleted_at'
+  }
+});
+
+exports.down = queryInterface => queryInterface.dropTable(TABLE_NAME);

--- a/server/shared/database/migrations/20181115140905-create-teaching-element.js
+++ b/server/shared/database/migrations/20181115140905-create-teaching-element.js
@@ -2,75 +2,74 @@
 
 const TABLE_NAME = 'teaching_element';
 
-module.exports = {
-  up: (queryInterface, Sequelize) => queryInterface.createTable(TABLE_NAME, {
-    id: {
-      type: Sequelize.INTEGER,
-      primaryKey: true,
-      autoIncrement: true
-    },
-    courseId: {
-      type: Sequelize.INTEGER,
-      field: 'course_id',
-      references: { model: 'course', key: 'id' }
-    },
-    activityId: {
-      type: Sequelize.INTEGER,
-      field: 'activity_id',
-      references: { model: 'activity', key: 'id' }
-    },
-    uid: {
-      type: Sequelize.UUID,
-      unique: true,
-      defaultValue: Sequelize.UUIDV4
-    },
-    type: {
-      type: Sequelize.STRING
-    },
-    position: {
-      type: Sequelize.DOUBLE
-    },
-    contentId: {
-      type: Sequelize.UUID,
-      field: 'content_id',
-      defaultValue: Sequelize.UUIDV4
-    },
-    contentSignature: {
-      type: Sequelize.STRING(40),
-      field: 'content_signature'
-    },
-    data: {
-      type: Sequelize.JSONB,
-      defaultValue: {}
-    },
-    refs: {
-      type: Sequelize.JSONB,
-      defaultValue: {}
-    },
-    linked: {
-      type: Sequelize.BOOLEAN,
-      defaultValue: false,
-      allowNull: false
-    },
-    detached: {
-      type: Sequelize.BOOLEAN,
-      defaultValue: false,
-      allowNull: false
-    },
-    createdAt: {
-      type: Sequelize.DATE,
-      field: 'created_at',
-      allowNull: false
-    },
-    updatedAt: {
-      type: Sequelize.DATE,
-      field: 'updated_at',
-      allowNull: false
-    },
-    deletedAt: {
-      type: Sequelize.DATE,
-      field: 'deleted_at'
-    }
-  }),
-  down: queryInterface => queryInterface.dropTable(TABLE_NAME)
-};
+exports.up = (queryInterface, Sequelize) => queryInterface.createTable(TABLE_NAME, {
+  id: {
+    type: Sequelize.INTEGER,
+    primaryKey: true,
+    autoIncrement: true
+  },
+  courseId: {
+    type: Sequelize.INTEGER,
+    field: 'course_id',
+    references: { model: 'course', key: 'id' }
+  },
+  activityId: {
+    type: Sequelize.INTEGER,
+    field: 'activity_id',
+    references: { model: 'activity', key: 'id' }
+  },
+  uid: {
+    type: Sequelize.UUID,
+    unique: true,
+    defaultValue: Sequelize.UUIDV4
+  },
+  type: {
+    type: Sequelize.STRING
+  },
+  position: {
+    type: Sequelize.DOUBLE
+  },
+  contentId: {
+    type: Sequelize.UUID,
+    field: 'content_id',
+    defaultValue: Sequelize.UUIDV4
+  },
+  contentSignature: {
+    type: Sequelize.STRING(40),
+    field: 'content_signature'
+  },
+  data: {
+    type: Sequelize.JSONB,
+    defaultValue: {}
+  },
+  refs: {
+    type: Sequelize.JSONB,
+    defaultValue: {}
+  },
+  linked: {
+    type: Sequelize.BOOLEAN,
+    defaultValue: false,
+    allowNull: false
+  },
+  detached: {
+    type: Sequelize.BOOLEAN,
+    defaultValue: false,
+    allowNull: false
+  },
+  createdAt: {
+    type: Sequelize.DATE,
+    field: 'created_at',
+    allowNull: false
+  },
+  updatedAt: {
+    type: Sequelize.DATE,
+    field: 'updated_at',
+    allowNull: false
+  },
+  deletedAt: {
+    type: Sequelize.DATE,
+    field: 'deleted_at'
+  }
+});
+
+exports.down = queryInterface => queryInterface.dropTable(TABLE_NAME);

--- a/server/shared/database/migrations/20181115140906-create-revision.js
+++ b/server/shared/database/migrations/20181115140906-create-revision.js
@@ -2,43 +2,42 @@
 
 const TABLE_NAME = 'revision';
 
-module.exports = {
-  up: (queryInterface, Sequelize) => queryInterface.createTable(TABLE_NAME, {
-    id: {
-      type: Sequelize.INTEGER,
-      primaryKey: true,
-      autoIncrement: true
-    },
-    userId: {
-      type: Sequelize.INTEGER,
-      field: 'user_id',
-      references: { model: 'user', key: 'id' }
-    },
-    courseId: {
-      type: Sequelize.INTEGER,
-      field: 'course_id',
-      references: { model: 'course', key: 'id' }
-    },
-    entity: {
-      type: Sequelize.ENUM(['ACTIVITY', 'COURSE', 'TEACHING_ELEMENT']),
-      allowNull: false
-    },
-    operation: {
-      type: Sequelize.ENUM(['CREATE', 'UPDATE', 'REMOVE']),
-      allowNull: false
-    },
-    state: {
-      type: Sequelize.JSONB,
-      allowNull: true
-    },
-    createdAt: {
-      type: Sequelize.DATE,
-      field: 'created_at'
-    },
-    updatedAt: {
-      type: Sequelize.DATE,
-      field: 'updated_at'
-    }
-  }),
-  down: queryInterface => queryInterface.dropTable(TABLE_NAME)
-};
+exports.up = (queryInterface, Sequelize) => queryInterface.createTable(TABLE_NAME, {
+  id: {
+    type: Sequelize.INTEGER,
+    primaryKey: true,
+    autoIncrement: true
+  },
+  userId: {
+    type: Sequelize.INTEGER,
+    field: 'user_id',
+    references: { model: 'user', key: 'id' }
+  },
+  courseId: {
+    type: Sequelize.INTEGER,
+    field: 'course_id',
+    references: { model: 'course', key: 'id' }
+  },
+  entity: {
+    type: Sequelize.ENUM(['ACTIVITY', 'COURSE', 'TEACHING_ELEMENT']),
+    allowNull: false
+  },
+  operation: {
+    type: Sequelize.ENUM(['CREATE', 'UPDATE', 'REMOVE']),
+    allowNull: false
+  },
+  state: {
+    type: Sequelize.JSONB,
+    allowNull: true
+  },
+  createdAt: {
+    type: Sequelize.DATE,
+    field: 'created_at'
+  },
+  updatedAt: {
+    type: Sequelize.DATE,
+    field: 'updated_at'
+  }
+});
+
+exports.down = queryInterface => queryInterface.dropTable(TABLE_NAME);

--- a/server/shared/database/migrations/20181115140907-create-comment.js
+++ b/server/shared/database/migrations/20181115140907-create-comment.js
@@ -2,44 +2,43 @@
 
 const TABLE_NAME = 'comment';
 
-module.exports = {
-  up: (queryInterface, Sequelize) => queryInterface.createTable(TABLE_NAME, {
-    id: {
-      type: Sequelize.INTEGER,
-      primaryKey: true,
-      autoIncrement: true
-    },
-    authorId: {
-      type: Sequelize.INTEGER,
-      field: 'author_id',
-      references: { model: 'user', key: 'id' }
-    },
-    activityId: {
-      type: Sequelize.INTEGER,
-      field: 'activity_id',
-      references: { model: 'activity', key: 'id' }
-    },
-    courseId: {
-      type: Sequelize.INTEGER,
-      field: 'course_id',
-      references: { model: 'course', key: 'id' }
-    },
-    content: {
-      type: Sequelize.TEXT,
-      allowNull: false
-    },
-    createdAt: {
-      type: Sequelize.DATE,
-      field: 'created_at'
-    },
-    updatedAt: {
-      type: Sequelize.DATE,
-      field: 'updated_at'
-    },
-    deletedAt: {
-      type: Sequelize.DATE,
-      field: 'deleted_at'
-    }
-  }),
-  down: queryInterface => queryInterface.dropTable(TABLE_NAME)
-};
+exports.up = (queryInterface, Sequelize) => queryInterface.createTable(TABLE_NAME, {
+  id: {
+    type: Sequelize.INTEGER,
+    primaryKey: true,
+    autoIncrement: true
+  },
+  authorId: {
+    type: Sequelize.INTEGER,
+    field: 'author_id',
+    references: { model: 'user', key: 'id' }
+  },
+  activityId: {
+    type: Sequelize.INTEGER,
+    field: 'activity_id',
+    references: { model: 'activity', key: 'id' }
+  },
+  courseId: {
+    type: Sequelize.INTEGER,
+    field: 'course_id',
+    references: { model: 'course', key: 'id' }
+  },
+  content: {
+    type: Sequelize.TEXT,
+    allowNull: false
+  },
+  createdAt: {
+    type: Sequelize.DATE,
+    field: 'created_at'
+  },
+  updatedAt: {
+    type: Sequelize.DATE,
+    field: 'updated_at'
+  },
+  deletedAt: {
+    type: Sequelize.DATE,
+    field: 'deleted_at'
+  }
+});
+
+exports.down = queryInterface => queryInterface.dropTable(TABLE_NAME);

--- a/server/shared/database/migrations/20181115140943-add-meta-to-teaching-element.js
+++ b/server/shared/database/migrations/20181115140943-add-meta-to-teaching-element.js
@@ -3,16 +3,15 @@
 const TABLE_NAME = 'teaching_element';
 const COLUMN_NAME = 'meta';
 
-module.exports = {
-  up: async (queryInterface, Sequelize) => {
-    const table = await queryInterface.describeTable(TABLE_NAME);
-    if (table.meta) return;
-    return queryInterface.addColumn(TABLE_NAME, COLUMN_NAME, {
-      type: Sequelize.JSONB,
-      defaultValue: {}
-    });
-  },
-  down: queryInterface => {
-    return queryInterface.removeColumn(TABLE_NAME, COLUMN_NAME);
-  }
+exports.up = async (queryInterface, Sequelize) => {
+  const table = await queryInterface.describeTable(TABLE_NAME);
+  if (table.meta) return;
+  return queryInterface.addColumn(TABLE_NAME, COLUMN_NAME, {
+    type: Sequelize.JSONB,
+    defaultValue: {}
+  });
+};
+
+exports.down = queryInterface => {
+  return queryInterface.removeColumn(TABLE_NAME, COLUMN_NAME);
 };

--- a/server/shared/database/migrations/20190416152610-change-table-cell-type.js
+++ b/server/shared/database/migrations/20190416152610-change-table-cell-type.js
@@ -14,21 +14,20 @@ function setCellType({ data }, type) {
   });
 }
 
-module.exports = {
-  up: async queryInterface => {
-    const tables = await findTables(queryInterface);
-    return Promise.all(tables.map(({ id, data }) => {
-      setCellType({ data }, 'HTML');
-      return queryInterface.update({}, TABLE_NAME, { data }, { id });
-    }));
-  },
-  down: async queryInterface => {
-    const tables = await findTables(queryInterface);
-    return Promise.all(tables.map(({ id, data }) => {
-      setCellType({ data }, 'TABLE-CELL');
-      return queryInterface.update({}, TABLE_NAME, { data }, { id });
-    }));
-  }
+exports.up = async queryInterface => {
+  const tables = await findTables(queryInterface);
+  return Promise.all(tables.map(({ id, data }) => {
+    setCellType({ data }, 'HTML');
+    return queryInterface.update({}, TABLE_NAME, { data }, { id });
+  }));
+};
+
+exports.down = async queryInterface => {
+  const tables = await findTables(queryInterface);
+  return Promise.all(tables.map(({ id, data }) => {
+    setCellType({ data }, 'TABLE-CELL');
+    return queryInterface.update({}, TABLE_NAME, { data }, { id });
+  }));
 };
 
 function mapKeys(obj, cb) {


### PR DESCRIPTION
This PR alters migration code format. Instead of using joint `module.exports` separate `exports` are being used 🦊 