### PR TITLE
TA-389 - Assessments publishing issue fix

### DIFF
--- a/server/shared/publishing/helpers.js
+++ b/server/shared/publishing/helpers.js
@@ -127,7 +127,6 @@ function publishExams(parent) {
 function publishAssessments(parent) {
   const options = { where: { type: 'ASSESSMENT' }, attributes: TES_ATTRS };
   return parent.getTeachingElements(options).then(assessments => {
-    if (!assessments.length) return Promise.resolve([]);
     const key = getAssessmentsKey(parent);
     return saveFile(parent, key, assessments).then(() => assessments);
   });


### PR DESCRIPTION
This PR fixes an issue with assessments publishing. Assessments stay published even if they are deleted. The solution was to remove empty assessments check before saveFile, so no assessments result in an empty file.