### PR TITLE
Registry creation without dynamic imports

### DIFF
--- a/client/ElementRegistry.js
+++ b/client/ElementRegistry.js
@@ -6,20 +6,17 @@ import {
 } from 'tce-core/utils';
 import cloneDeep from 'lodash/cloneDeep';
 import elementList from './components/content-elements';
-import extensionsList from '../extensions/content-elements';
+import extensionList from '../extensions/content-elements';
 import find from 'lodash/find';
 import pick from 'lodash/pick';
-import Promise from 'bluebird';
 
 export default class ElementRegistry {
   constructor(Vue) {
     this._registry = [];
     this.Vue = Vue;
-  }
 
-  initialize() {
-    const list = [...elementList, ...extensionsList];
-    return Promise.map(list, (item, index) => this.load(item, index));
+    const list = [...elementList, ...extensionList];
+    list.map((item, index) => this.load(item, index));
   }
 
   load(element, position = this._registry.length) {

--- a/client/components/content-elements/index.js
+++ b/client/components/content-elements/index.js
@@ -1,22 +1,43 @@
+import TceAccordion from './tce-accordion';
+import TceAudio from './tce-audio';
+import TceBrightcoveVideo from './tce-brightcove-video';
+import TceCarousel from './tce-carousel';
+import TceDragDrop from './tce-drag-drop';
+import TceEmbed from './tce-embed';
+import TceFillBlank from './tce-fill-blank';
+import TceHtml from './tce-html';
+import TceImage from './tce-image';
+import TceMatchingQuestion from './tce-matching-question';
+import TceModal from './tce-modal';
+import TceMultipleChoice from './tce-multiple-choice';
+import TceNumericalResponse from './tce-numerical-response';
+import TcePageBreak from './tce-page-break';
+import TcePdf from './tce-pdf';
+import TceSingleChoice from './tce-single-choice';
+import TceTable from './tce-table';
+import TceTextResponse from './tce-text-response';
+import TceTrueFalse from './tce-true-false';
+import TceVideo from './tce-video';
+
 export default [
-  'tce-html',
-  'tce-image',
-  'tce-video',
-  'tce-embed',
-  'tce-audio',
-  'tce-page-break',
-  'tce-pdf',
-  'tce-accordion',
-  'tce-table',
-  'tce-modal',
-  'tce-carousel',
-  'tce-brightcove-video',
-  'tce-multiple-choice',
-  'tce-single-choice',
-  'tce-true-false',
-  'tce-text-response',
-  'tce-numerical-response',
-  'tce-fill-blank',
-  'tce-matching-question',
-  'tce-drag-drop'
+  TceHtml,
+  TceImage,
+  TceVideo,
+  TceEmbed,
+  TceAudio,
+  TcePageBreak,
+  TcePdf,
+  TceAccordion,
+  TceTable,
+  TceModal,
+  TceCarousel,
+  TceBrightcoveVideo,
+  TceMultipleChoice,
+  TceSingleChoice,
+  TceTrueFalse,
+  TceTextResponse,
+  TceNumericalResponse,
+  TceFillBlank,
+  TceMatchingQuestion,
+  TceDragDrop
 ];

--- a/client/main.js
+++ b/client/main.js
@@ -50,20 +50,17 @@ Vue.use(Timeago, {
   }
 });
 
-const registry = new ElementRegistry(Vue);
-registry.initialize().then(() => {
-  sync(store, router);
-  /* eslint-disable no-new */
-  new Vue({
-    router,
-    store,
-    el: '#app',
-    render: h => h(App),
-    provide() {
-      return {
-        $teRegistry: registry,
-        $storageService: assetsApi
-      };
-    }
-  });
+sync(store, router);
+/* eslint-disable no-new */
+new Vue({
+  router,
+  store,
+  el: '#app',
+  render: h => h(App),
+  provide() {
+    return {
+      $teRegistry: new ElementRegistry(Vue),
+      $storageService: assetsApi
+    };
+  }
 });


### PR DESCRIPTION
This version of the registry creation functions without dynamic imports. The reason for this proposed change is to allow custom teaching elements to use packages that do not exist in Tailor without requiring them to be built beforehand.