### PR TITLE
Add Multiselect meta type

### DIFF
--- a/client/components/common/Meta/BaseSelect.vue
+++ b/client/components/common/Meta/BaseSelect.vue
@@ -27,16 +27,14 @@
 
 <script>
 import isString from 'lodash/isString';
-import Select from '../../common/Select';
+import Select from '@/components/common/Select';
 
 export default {
   name: 'base-meta-select',
   props: {
     meta: { type: Object, default: () => ({ value: null }) }
   },
-  data() {
-    return { active: false };
-  },
+  data: () => ({ active: false }),
   computed: {
     isMultiSelect: () => {
       throw new Error('Computed "isMultiSelect" must be implemented');

--- a/client/components/common/Meta/BaseSelect.vue
+++ b/client/components/common/Meta/BaseSelect.vue
@@ -9,6 +9,7 @@
       :options="options"
       :searchable="false"
       :placeholder="meta.placeholder"
+      :multiple="isMultiSelect"
       @open="active = true"
       @close="active = false"
       @input="update">
@@ -25,13 +26,11 @@
 </template>
 
 <script>
-import find from 'lodash/find';
-import get from 'lodash/get';
 import isString from 'lodash/isString';
 import Select from '../../common/Select';
 
 export default {
-  name: 'multi-select',
+  name: 'base-meta-select',
   props: {
     meta: { type: Object, default: () => ({ value: null }) }
   },
@@ -39,8 +38,11 @@ export default {
     return { active: false };
   },
   computed: {
-    value() {
-      return find(this.options, { value: this.meta.value });
+    isMultiSelect: () => {
+      throw new Error('Computed "isMultiSelect" must be implemented');
+    },
+    value: () => {
+      throw new Error('Computed "value" must be implemented');
     },
     options() {
       const { options } = this.meta;
@@ -48,8 +50,12 @@ export default {
     }
   },
   methods: {
+    parseInput() {
+      throw new Error('Method "parseInput" must be implemented');
+    },
     update(data) {
-      return this.$emit('update', this.meta.key, get(data, 'value', null));
+      const payload = this.parseInput(data);
+      return this.$emit('update', this.meta.key, payload);
     }
   },
   components: { multiselect: Select }

--- a/client/components/common/Meta/Multiselect.js
+++ b/client/components/common/Meta/Multiselect.js
@@ -1,17 +1,17 @@
 import BaseSelect from './BaseSelect';
 
+const includes = (arr, ...args) => arr.includes(...args);
+
 export default {
   name: 'meta-multiselect',
   extends: BaseSelect,
   computed: {
     isMultiSelect: () => true,
-    value() {
-      return this.options.filter(it => (this.meta.value || []).includes(it.value));
+    value: ({ meta, options }) => {
+      return options.filter(it => includes(meta.value || [], it.value));
     }
   },
   methods: {
-    parseInput(data = []) {
-      return data.map(it => it.value);
-    }
+    parseInput: (data = []) => data.map(it => it.value)
   }
 };

--- a/client/components/common/Meta/Multiselect.js
+++ b/client/components/common/Meta/Multiselect.js
@@ -1,0 +1,17 @@
+import BaseSelect from './BaseSelect';
+
+export default {
+  name: 'meta-multiselect',
+  extends: BaseSelect,
+  computed: {
+    isMultiSelect: () => true,
+    value() {
+      return this.options.filter(it => (this.meta.value || []).includes(it.value));
+    }
+  },
+  methods: {
+    parseInput(data = []) {
+      return data.map(it => it.value);
+    }
+  }
+};

--- a/client/components/common/Meta/Select.js
+++ b/client/components/common/Meta/Select.js
@@ -1,17 +1,13 @@
 import BaseSelect from './BaseSelect';
-import find from 'lodash/find';
-import get from 'lodash/get';
 
 export default {
   name: 'meta-select',
   extends: BaseSelect,
   computed: {
     isMultiSelect: () => false,
-    value() {
-      return find(this.options, { value: this.meta.value });
-    }
+    value: ({ meta, options }) => options.find(it => it.value === meta.value)
   },
   methods: {
-    parseInput: data => get(data, 'value', null)
+    parseInput: ({ data }) => data.value || null
   }
 };

--- a/client/components/common/Meta/Select.js
+++ b/client/components/common/Meta/Select.js
@@ -1,0 +1,17 @@
+import BaseSelect from './BaseSelect';
+import find from 'lodash/find';
+import get from 'lodash/get';
+
+export default {
+  name: 'meta-select',
+  extends: BaseSelect,
+  computed: {
+    isMultiSelect: () => false,
+    value() {
+      return find(this.options, { value: this.meta.value });
+    }
+  },
+  methods: {
+    parseInput: data => get(data, 'value', null)
+  }
+};

--- a/client/components/common/Meta/index.vue
+++ b/client/components/common/Meta/index.vue
@@ -1,6 +1,6 @@
 <template>
   <component
-    :is="resolveComponent(meta.type)"
+    :is="component"
     :meta="meta"
     @update="(key, value) => $emit('update', key, value)">
   </component>
@@ -13,6 +13,7 @@ import DatePicker from './DatePicker';
 import FileUpload from './File';
 import Input from './Input';
 import mapKeys from 'lodash/mapKeys';
+import Multiselect from './Multiselect';
 import Select from './Select';
 import Switch from './Switch';
 import Textarea from './Textarea';
@@ -24,6 +25,7 @@ const META_TYPES = {
   DATETIME: DatePicker,
   INPUT: Input,
   SELECT: Select,
+  MULTISELECT: Multiselect,
   SWITCH: Switch,
   TEXTAREA: Textarea,
   FILE: FileUpload
@@ -34,10 +36,9 @@ export default {
   props: {
     meta: { type: Object, required: true }
   },
-  methods: {
-    resolveComponent(type = '') {
-      return META_TYPES[type.toUpperCase()] || META_TYPES.INPUT;
-    }
+  computed: {
+    type: vm => (vm.meta.type || '').toUpperCase(),
+    component: vm => META_TYPES[vm.type] || META_TYPES.INPUT
   },
   components
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10666,7 +10666,6 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.4.tgz",
       "integrity": "sha512-mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==",
       "dev": true,
-      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -10676,8 +10675,7 @@
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -18833,7 +18831,7 @@
     "vue-video-player": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/vue-video-player/-/vue-video-player-3.1.4.tgz",
-      "integrity": "sha1-cAmwbc7EObPqZFGDIX0xTL8NN/0=",
+      "integrity": "sha512-CqVvhy2QSDRxXfaHn029Cpz+mbV2gubIcdZE5Uu1e7f0ZfpdqpuqnSYyE50nUXzM3zfa7TaYOARpLsY3FdLtOQ==",
       "requires": {
         "video.js": "^5.11.7"
       }
@@ -19309,8 +19307,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -19331,14 +19328,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -19353,20 +19348,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -19483,8 +19475,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -19496,7 +19487,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -19511,7 +19501,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -19519,14 +19508,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -19545,7 +19532,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -19626,8 +19612,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -19639,7 +19624,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -19725,8 +19709,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -19762,7 +19745,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -19782,7 +19764,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -19826,14 +19807,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },


### PR DESCRIPTION
This PR adds `MULTISELECT` meta type.

The reasoning behind adding a new meta type instead of adding an option to existing `SELECT` meta type:
- to preserve published value types consistency (`SELECT` produces a single value, while `MULTISELECT` produces an Array of values)
- ease out LMS/consumer data parsing
- avoid possible breaks of backward compatibility for existing `SELECT` meta type