### PR TITLE
Removing cuid and using only uuid for store

### DIFF
--- a/client/components/catalog/Container.vue
+++ b/client/components/catalog/Container.vue
@@ -14,7 +14,7 @@
     <div v-show="!searching" class="row course-list">
       <course-card
         v-for="course in orderedCourses"
-        :key="course._cid"
+        :key="course.uid"
         :course="course">
       </course-card>
       <infinite-loading ref="infiniteLoading" @infinite="loadMore">

--- a/client/components/course/Outline/Activity.vue
+++ b/client/components/course/Outline/Activity.vue
@@ -49,10 +49,10 @@
         </div>
       </div>
       <insert-activity
-        :anchor="{ id, _cid, parentId, courseId, type, position }"
+        :anchor="{ id, uid, parentId, courseId, type, position }"
         @expand="toggle(true)"/>
     </div>
-    <div v-if="!isCollapsed({ _cid }) && hasChildren">
+    <div v-if="!isCollapsed({ uid }) && hasChildren">
       <draggable
         :list="children"
         :options="{ handle: '.activity' }"
@@ -60,7 +60,7 @@
         <activity
           v-for="(subActivity, index) in children"
           v-bind="subActivity"
-          :key="subActivity._cid"
+          :key="subActivity.uid"
           :index="index + 1"
           :level="level + 1"
           :activities="activities"
@@ -86,7 +86,7 @@ export default {
   mixins: [reorderMixin],
   inheritAttrs: false,
   props: {
-    _cid: { type: String, required: true },
+    uid: { type: String, required: true },
     id: { type: Number, default: null },
     parentId: { type: Number, default: null },
     courseId: { type: Number, required: true },
@@ -119,13 +119,13 @@ export default {
       return isEditable(this.type);
     },
     isSelected() {
-      return this.focusedActivity._cid === this._cid;
+      return this.focusedActivity.uid === this.uid;
     },
     isHighlighted() {
       return this.isHovered || this.isSelected;
     },
     isExpanded() {
-      return !this.isCollapsed({ _cid: this._cid });
+      return !this.isCollapsed({ uid: this.uid });
     },
     hasSubtypes() {
       return !!size(this.config.subLevels);
@@ -134,7 +134,7 @@ export default {
       return (this.children.length > 0) && this.hasSubtypes;
     },
     showOptions() {
-      return this._cid === this.outlineState.showOptions;
+      return this.uid === this.outlineState.showOptions;
     },
     children() {
       const level = this.level + 1;
@@ -154,11 +154,11 @@ export default {
     ...mapMutations('course',
       ['focusActivity', 'toggleActivity', 'showActivityOptions']),
     focus(options = false) {
-      this.focusActivity(this._cid);
-      return this.showActivityOptions(options ? this._cid : null);
+      this.focusActivity(this.uid);
+      return this.showActivityOptions(options ? this.uid : null);
     },
     toggle(expanded = !this.isExpanded) {
-      this.toggleActivity({ _cid: this._cid, expanded });
+      this.toggleActivity({ uid: this.uid, expanded });
     }
   },
   components: { Draggable, InsertActivity }

--- a/client/components/course/Outline/InsertActivity/index.vue
+++ b/client/components/course/Outline/InsertActivity/index.vue
@@ -60,7 +60,7 @@ export default {
     ...mapGetters('course', ['structure']),
     ...mapState({ outlineState: s => s.course.outline }),
     showActions() {
-      return this.anchor._cid === this.outlineState.showOptions;
+      return this.anchor.uid === this.outlineState.showOptions;
     },
     supportedLevels() {
       const grandParent = getParent(this.activities, this.anchor);
@@ -76,8 +76,8 @@ export default {
     ...mapActions('activities', { copy: 'clone', create: 'save' }),
     ...mapMutations('course', ['showActivityOptions', 'focusActivity']),
     show() {
-      this.showActivityOptions(this.anchor._cid);
-      this.focusActivity(this.anchor._cid);
+      this.showActivityOptions(this.anchor.uid);
+      this.focusActivity(this.anchor.uid);
     },
     hide() {
       this.showActivityOptions(null);

--- a/client/components/course/Outline/NoActivities.vue
+++ b/client/components/course/Outline/NoActivities.vue
@@ -75,7 +75,7 @@ export default {
         })
         .then(() => {
           const activity = first(this.activities);
-          if (activity) this.focusActivity(activity._cid);
+          if (activity) this.focusActivity(activity.uid);
         });
       });
     }

--- a/client/components/course/Outline/index.vue
+++ b/client/components/course/Outline/index.vue
@@ -23,7 +23,7 @@
           <activity
             v-for="(activity, index) in rootActivities"
             v-bind="activity"
-            :key="activity._cid"
+            :key="activity.uid"
             :index="index + 1"
             :level="1"
             :activities="outlineActivities"/>

--- a/client/components/course/Sidebar/Body.vue
+++ b/client/components/course/Sidebar/Body.vue
@@ -7,7 +7,7 @@
     <div class="meta-element">
       <meta-input
         v-for="it in metadata"
-        :key="`${activity._cid}.${it.key}`"
+        :key="`${activity.uid}.${it.key}`"
         :meta="it"
         @update="updateActivity">
       </meta-input>
@@ -16,7 +16,7 @@
       <relationship
         v-for="relationship in config.relationships"
         v-bind="relationship"
-        :key="`${activity._cid}.${relationship.type}`">
+        :key="`${activity.uid}.${relationship.type}`">
       </relationship>
     </div>
     <discussion
@@ -48,7 +48,7 @@ export default {
     ...mapActions('activities', ['update']),
     updateActivity(key, value) {
       const data = { ...this.activity.data, [key]: value };
-      this.update({ _cid: this.activity._cid, data });
+      this.update({ _cid: this.activity.uid, data });
     }
   },
   components: {

--- a/client/components/course/Sidebar/Publishing.vue
+++ b/client/components/course/Sidebar/Publishing.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :key="activity._cid" class="publish-container">
+  <div :key="activity.uid" class="publish-container">
     <div class="publish-date">
       <span>{{ publishedAtMessage }}</span>
     </div>

--- a/client/components/course/Sidebar/index.vue
+++ b/client/components/course/Sidebar/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :key="activity._cid" class="course-sidebar elevation-1">
+  <div :key="activity.uid" class="course-sidebar elevation-1">
     <div v-if="activitySelected">
       <sidebar-header></sidebar-header>
       <sidebar-body></sidebar-body>
@@ -24,7 +24,7 @@ export default {
   computed: {
     ...mapGetters('course', ['activity']),
     activitySelected() {
-      return !!this.activity._cid;
+      return !!this.activity.uid;
     }
   },
   components: {

--- a/client/components/course/TreeView/index.vue
+++ b/client/components/course/TreeView/index.vue
@@ -74,7 +74,7 @@ export default {
     onNodeSelect(node, activity, circle) {
       if (!isActivityNode(node)) return;
       this.setSelected(circle);
-      this.focusActivity(activity._cid);
+      this.focusActivity(activity.uid);
     }
   },
   components: {

--- a/client/components/course/index.vue
+++ b/client/components/course/index.vue
@@ -77,7 +77,7 @@ export default {
     this.showLoader = false;
     const activities = filter(this.activities, { parentId: null });
     if (!existingSelection && activities.length) {
-      this.resetActivityFocus(sortBy(activities, 'position')[0]._cid);
+      this.resetActivityFocus(sortBy(activities, 'position')[0].uid);
     }
   }
 };

--- a/client/store/helpers/actions.js
+++ b/client/store/helpers/actions.js
@@ -1,4 +1,3 @@
-import cuid from 'cuid';
 import Resource from './resource';
 
 export default function ($apiUrl) {
@@ -21,15 +20,13 @@ export default function ($apiUrl) {
   };
 
   const save = ({ state, commit }, model) => {
-    if (!model._cid) model._cid = cuid();
     model._synced = false;
     model._version = Date.now();
     // Create or update model locally.
-    commit('save', model);
     return api.save(model).then(model => {
       // Check if new change happened locally during api call.
       // Do not update meta if there is newer change.
-      const previous = state.items[model._cid];
+      const previous = state.items[model.uid];
       if (previous && previous._version === model._version) model._synced = true;
       commit('save', model);
     });

--- a/client/store/helpers/mutations.js
+++ b/client/store/helpers/mutations.js
@@ -1,9 +1,8 @@
-import cuid from 'cuid';
 import each from 'lodash/each';
 import Vue from 'vue';
 
 export const fetch = (state, items) => {
-  each(items, it => Vue.set(state.items, it._cid, it));
+  each(items, it => Vue.set(state.items, it.uid, it));
 };
 
 export const reset = (state, items = {}) => {
@@ -11,16 +10,16 @@ export const reset = (state, items = {}) => {
 };
 
 export const add = (state, model) => {
-  const _cid = model._cid || cuid();
-  Vue.set(state.items, _cid, { ...model, _cid });
+  const uid = model.uid;
+  Vue.set(state.items, uid, { ...model });
 };
 
 export const save = (state, model) => {
-  Vue.set(state.items, model._cid, model);
+  Vue.set(state.items, model.uid, model);
 };
 
 export const remove = (state, models) => {
-  models.forEach(it => Vue.delete(state.items, it._cid));
+  models.forEach(it => Vue.delete(state.items, it.uid));
 };
 
 export const setEndpoint = (state, url) => {

--- a/client/store/modules/activities/mutations.js
+++ b/client/store/modules/activities/mutations.js
@@ -1,7 +1,7 @@
 import { add, fetch, remove, reset, save, setEndpoint } from '../../helpers/mutations';
 
 const reorder = (state, { activity, position }) => {
-  state.items[activity._cid].position = position;
+  state.items[activity.uid].position = position;
 };
 
 export { add, fetch, remove, reorder, reset, save, setEndpoint };

--- a/client/store/modules/course/getters.js
+++ b/client/store/modules/course/getters.js
@@ -36,7 +36,7 @@ export const outlineActivities = (_, getters) => {
 };
 
 export const isCollapsed = state => {
-  return activity => activity && !state.outline.expanded[activity._cid];
+  return activity => activity && !state.outline.expanded[activity.uid];
 };
 
 export const revisions = (_state, { course }, _rootState, rootGetters) => {

--- a/client/store/modules/course/mutations.js
+++ b/client/store/modules/course/mutations.js
@@ -2,24 +2,24 @@ import compact from 'lodash/compact';
 import transform from 'lodash/transform';
 import Vue from 'vue';
 
-export const focusActivity = (state, _cid) => {
-  state.activity = _cid;
+export const focusActivity = (state, uid) => {
+  state.activity = uid;
 };
 
-export const showActivityOptions = (state, _cid) => {
-  state.outline.showOptions = _cid;
+export const showActivityOptions = (state, uid) => {
+  state.outline.showOptions = uid;
 };
 
-export const toggleActivity = (state, { _cid, expanded }) => {
+export const toggleActivity = (state, { uid, expanded }) => {
   const expandedItems = state.outline.expanded;
-  expanded = expanded === undefined ? !expandedItems[_cid] : expanded;
-  Vue.set(expandedItems, _cid, expanded);
+  expanded = expanded === undefined ? !expandedItems[uid] : expanded;
+  Vue.set(expandedItems, uid, expanded);
 };
 
 export const toggleActivities = (state, outline) => {
   const totalExpanded = compact(Object.values(state.outline.expanded)).length;
   const isOpen = totalExpanded < outline.length;
-  const expanded = transform(outline, (acc, it) => (acc[it._cid] = isOpen), {});
+  const expanded = transform(outline, (acc, it) => (acc[it.uid] = isOpen), {});
   Vue.set(state.outline, 'expanded', expanded);
 };
 


### PR DESCRIPTION
While working on #275, I encountered several issues related to `cuid` (`_cid`) when updating activities which are linked or adding activity into a linked tree. 

When updating a linked activity, origin gets updated, but from backend all linked activities are return, thus meaning that response is `array`. Frontend expects one updated activity with `cuid` added on frontend beforehand and attached when return from backend. In updating links this scenario doesn't work without hacks. 

Things get messy when you want to add a new activity into a linked subtree (in current state of specification for linking this is possible). You need to add one activity, from backend there activities are returned (origin and two links or more links, depending how many time one activity is linked). Again, frontend assigns  `cuid` beforehand and through manipulation reapplies the same `cuid` on return when saving in store, but in this scenario backend again returns an `array`, but frontend served only one `cuid` for one added activity. 

To make all this work, a lot of hacky updates and conditions should be applied on `vuex` store, especially in [resource helper](https://github.com/ExtensionEngine/tailor/blob/develop/client/store/helpers/resource.js) and mutations as well. 

Also, one major drawback, IMHO, that `cuid`'s are not persisted. 

Luckily, `uuid`'s are available  in the database and they can be easily replace `cuid`. Using `uuid`'s would easily solved this problem and other potential bulk operations. 

This PR demonstrates how that could work. Commit just swaps cuid with uuid in several key places, all major actions with activities work out of the box. 

Does this makes sense? 