### PR TITLE
Rremove unused vue-directive-tooltip

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -4,7 +4,6 @@ import 'dom-shims/shim/Element.classList';
 import 'dom-shims/shim/Element.mutation';
 import 'event-source-polyfill';
 import 'bootstrap-sass/assets/javascripts/bootstrap';
-import 'vue-directive-tooltip/css/index.css';
 
 import assetsApi from '@/api/asset';
 import colors from 'vuetify/es5/util/colors';
@@ -14,7 +13,6 @@ import FileFilter from '@/directives/file-filter';
 import QuestionContainer from 'tce-core/QuestionContainer';
 import { sync } from 'vuex-router-sync';
 import Timeago from 'vue-timeago';
-import Tooltip from 'vue-directive-tooltip';
 import VeeValidate from './utils/validation';
 import Vue from 'vue';
 import VueHotkey from 'v-hotkey';
@@ -42,7 +40,6 @@ Vue.use(Vuetify, {
   }
 });
 Vue.use(VuetifySnackbar);
-Vue.use(Tooltip, { delay: 50 });
 Vue.use(VeeValidate, {
   delay: 700,
   fieldsBagName: 'vFields',

--- a/package-lock.json
+++ b/package-lock.json
@@ -10671,7 +10671,6 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.4.tgz",
       "integrity": "sha512-mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==",
       "dev": true,
-      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -10681,8 +10680,7 @@
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -18711,14 +18709,6 @@
       "resolved": "https://registry.npmjs.org/vue-datetime/-/vue-datetime-1.0.0-beta.10.tgz",
       "integrity": "sha512-/wJkj95JSzWqH0Ja4JpXX6I+fXo2A34GCtsx00vR5RjNxk3++93rg7G4ZlI3MFo807zH9bIxXfIohbAZgnAWbQ=="
     },
-    "vue-directive-tooltip": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/vue-directive-tooltip/-/vue-directive-tooltip-1.5.1.tgz",
-      "integrity": "sha512-2v16flWOSM2gp/pNLje29lJXmWq4ib0NjoAn4wY5R1pYzy0S9a/q3dhQ7dgoqQ1ePXYOj3EpZxMVO8AQ1Zod/A==",
-      "requires": {
-        "popper.js": "1.12.5"
-      }
-    },
     "vue-eslint-parser": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-2.0.3.tgz",
@@ -19317,8 +19307,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -19339,14 +19328,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -19361,20 +19348,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -19491,8 +19475,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -19504,7 +19487,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -19519,7 +19501,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -19527,14 +19508,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -19553,7 +19532,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -19634,8 +19612,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -19647,7 +19624,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -19733,8 +19709,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -19770,7 +19745,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -19790,7 +19764,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -19834,14 +19807,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
     "vue-avatar": "^2.1.1",
     "vue-color": "^2.7.0",
     "vue-datetime": "^1.0.0-beta.3",
-    "vue-directive-tooltip": "^1.4.2",
     "vue-focus": "^2.1.0",
     "vue-infinite-loading": "^2.4.4",
     "vue-infinite-scroll": "^2.0.0",


### PR DESCRIPTION
#### Issue
On some cases of `npm install`, `vue-directive-tooltip` set to `^1.4.2` in `package.json` would install latest version `1.6.2` which has a different folder structure and import of the .css file in `client/main.js` would break.

#### Fix
Dependency isn't used anymore so it can be removed.