### PR TITLE
Fix multiselect placeholder overlay

### DIFF
--- a/client/components/common/Select.vue
+++ b/client/components/common/Select.vue
@@ -217,7 +217,6 @@ export default {
   }
 
   .multiselect__input {
-    width: 100% !important;
     margin: 0;
     padding-left: 10px;
     line-height: 32px;


### PR DESCRIPTION
Before:
![Screenshot from 2019-08-09 08-36-42](https://user-images.githubusercontent.com/2808092/62759226-ff1a3a80-ba80-11e9-9c36-0d5d9979a295.png)

After:
![Screenshot from 2019-08-09 08-36-28](https://user-images.githubusercontent.com/2808092/62759236-03deee80-ba81-11e9-9dd1-61690a84ec98.png)

I went through all the (multi)select elements that I could find and none of them seem to be broken after this change.