### PR TITLE
Support multiple types in tes meta configuration

### DIFF
--- a/config/shared/activities.js
+++ b/config/shared/activities.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const castArray = require('lodash/castArray');
 const filter = require('lodash/filter');
 const find = require('lodash/find');
 const first = require('lodash/first');
@@ -64,7 +65,8 @@ function getLevel(type) {
 }
 
 function getTesMeta(schemaId, type) {
-  return find(getSchema(schemaId).tesMeta, { type }) || {};
+  const { tesMeta } = getSchema(schemaId);
+  return find(tesMeta, it => castArray(it.type).includes(type)) || {};
 }
 
 function getSiblingLevels(type) {


### PR DESCRIPTION
The same tesMeta can be shared between different types of teaching elements