### PR TITLE
Removed ACL grant option on image save

### DIFF
--- a/server/shared/storage/helpers.js
+++ b/server/shared/storage/helpers.js
@@ -139,7 +139,8 @@ resolver.IMAGE = asset => {
 };
 
 function saveFile(key, file) {
-  const options = { ACL: 'public-read', ContentType: mime.lookup(key) };
+  // TODO: Investigate and properly set 'ACL' grant in options
+  const options = { ContentType: mime.lookup(key) };
   return storage.saveFile(key, file, options);
 }
 


### PR DESCRIPTION
Setting ACL grant to `public read` would result in an 'Access denied' error when trying to save an image to a bucket which is blocking public access.