### PR TITLE
Resolve storage asset keys as JSON paths

### DIFF
--- a/server/shared/storage/helpers.js
+++ b/server/shared/storage/helpers.js
@@ -10,6 +10,7 @@ const Promise = require('bluebird');
 const storage = require('./index');
 const toPairs = require('lodash/toPairs');
 const values = require('lodash/values');
+const set = require('lodash/set');
 
 const STORAGE_PROTOCOL = 'storage://';
 const PRIMITIVES = ['HTML', 'TABLE-CELL', 'IMAGE', 'BRIGHTCOVE_VIDEO', 'VIDEO', 'EMBED'];
@@ -80,9 +81,10 @@ async function resolveStatics(item) {
   if (!element.data.assets) return element;
   await Promise.map(toPairs(element.data.assets), async ([key, url]) => {
     const isStorageResource = url.startsWith(STORAGE_PROTOCOL);
-    element.data[key] = isStorageResource
+    const resolvedUrl = isStorageResource
       ? (await getFileUrl(url.substr(STORAGE_PROTOCOL.length, url.length)))
       : url;
+    set(element.data, key, resolvedUrl);
   });
   return element;
 }


### PR DESCRIPTION
E.g. a data object in the format of:
```js
{
  assets: { 'a.b': 'storage://some.url' }
}
```
would after resolving be:
```js
{
  assets: { 'a.b': 'storage://url' },
  a: { b: 'http://prefix/url' }
}
```