### PR TITLE
Allow custom container summary

### DIFF
--- a/server/shared/content-plugins/containerRegistry.js
+++ b/server/shared/content-plugins/containerRegistry.js
@@ -10,11 +10,13 @@ class ContainerRegistry extends BaseRegistry {
   constructor() {
     super('container', containerList, EXTENSIONS_LIST);
     this._staticsResolver = {};
+    this._summaryBuilder = {};
   }
 
   async initialize() {
     await super.initialize();
     this.buildStaticResolver();
+    this.buildSummaryBuilder();
   }
 
   fetch(...attrs) {
@@ -30,8 +32,18 @@ class ContainerRegistry extends BaseRegistry {
       .forEach(it => Object.assign(resolver, { [it.type]: it.resolve }));
   }
 
+  buildSummaryBuilder() {
+    const { _registry: registry, _summaryBuilder: builder } = this;
+    registry
+      .forEach(it => Object.assign(builder, { [it.type]: it.buildSummary }));
+  }
+
   getStaticsResolver(type) {
     return this._staticsResolver[type];
+  }
+
+  getSummaryBuilder(type) {
+    return this._summaryBuilder[type];
   }
 }
 

--- a/server/shared/publishing/helpers.js
+++ b/server/shared/publishing/helpers.js
@@ -250,11 +250,18 @@ function getRepositoryAttrs(repository) {
 }
 
 function attachContentSummary(obj, { containers, assessments }) {
-  obj.contentContainers = map(containers, it => ({
-    ...pick(it, ['id', 'uid', 'type', 'publishedAs']),
-    elementCount: get(it.elements, 'length', 0)
-  }));
+  obj.contentContainers = map(containers, getContainerSummary);
   obj.assessments = map(assessments, it => pick(it, ['id', 'uid']));
+}
+
+function getContainerSummary(container) {
+  const customBuilder = containerRegistry.getSummaryBuilder(container.type);
+  return customBuilder
+    ? customBuilder(container)
+    : {
+      ...pick(container, ['id', 'uid', 'type', 'publishedAs']),
+      elementCount: get(container.elements, 'length', 0)
+    };
 }
 
 function getActivityFilenames(spineActivity) {

--- a/server/shared/publishing/helpers.js
+++ b/server/shared/publishing/helpers.js
@@ -258,10 +258,11 @@ function getContainerSummary(container) {
   const customBuilder = containerRegistry.getSummaryBuilder(container.type);
   return customBuilder
     ? customBuilder(container)
-    : {
-      ...pick(container, ['id', 'uid', 'type', 'publishedAs']),
-      elementCount: get(container.elements, 'length', 0)
-    };
+    : defaultSummaryBuilder(container);
+}
+
+function defaultSummaryBuilder({ id, uid, type, publishedAs, elements = [] }) {
+  return { id, uid, type, publishedAs, elementCount: elements.length };
 }
 
 function getActivityFilenames(spineActivity) {


### PR DESCRIPTION
This PR adds the option to export `buildSummary` method from custom containers `util.js` to allow the custom container to build a custom container summary in the published content outline.
If no method is supplied generic summary fallback is used.

Example use-case: Custom container has sub-containers that need to be surfaced to container summary in the outline.
