### PR TITLE
Remove existing comments from fetch

### DIFF
--- a/client/store/helpers/resource.js
+++ b/client/store/helpers/resource.js
@@ -44,8 +44,10 @@ export default class Resource {
    */
   processEntries(items) {
     return reduce(items, (acc, it) => {
-      this.setCid(it);
-      acc[it._cid] = it;
+      if (!this.getCid(it.id)) {
+        this.setCid(it);
+        acc[it._cid] = it;
+      }
       return acc;
     }, {});
   }

--- a/client/store/helpers/resource.js
+++ b/client/store/helpers/resource.js
@@ -44,10 +44,8 @@ export default class Resource {
    */
   processEntries(items) {
     return reduce(items, (acc, it) => {
-      if (!this.getCid(it.id)) {
-        this.setCid(it);
-        acc[it._cid] = it;
-      }
+      this.setCid(it);
+      acc[it._cid] = it;
       return acc;
     }, {});
   }

--- a/client/store/modules/comments/actions.js
+++ b/client/store/modules/comments/actions.js
@@ -1,14 +1,21 @@
 import generateActions from '../../helpers/actions';
+import map from 'lodash/map';
+import pickBy from 'lodash/pickBy';
 import SSEClient from '../../../SSEClient';
 
 const { api, get, save, setEndpoint, update } = generateActions();
 let SSE_CLIENT;
 
+const filterExistingComment = (existingComments, fetchedComments) => {
+  const existingId = map(existingComments, 'id');
+  return pickBy(fetchedComments, it => !existingId.includes(it.id));
+};
+
 const fetch = ({ state, commit }, { id, repositoryId }) => {
   const action = state.repositoryId === repositoryId ? 'fetch' : 'reset';
   if (action === 'reset') commit('setRepository', repositoryId);
   return api.fetch({ activityId: id }).then(items => {
-    commit(action, items);
+    commit(action, filterExistingComment(state.items, items));
     commit('commentsFetched', id);
   });
 };

--- a/client/store/modules/comments/actions.js
+++ b/client/store/modules/comments/actions.js
@@ -1,21 +1,20 @@
+import find from 'lodash/find';
 import generateActions from '../../helpers/actions';
-import map from 'lodash/map';
-import pickBy from 'lodash/pickBy';
+import omitBy from 'lodash/omitBy';
 import SSEClient from '../../../SSEClient';
 
 const { api, get, save, setEndpoint, update } = generateActions();
 let SSE_CLIENT;
 
-const filterExistingComment = (existingComments, fetchedComments) => {
-  const existingId = map(existingComments, 'id');
-  return pickBy(fetchedComments, it => !existingId.includes(it.id));
+const omitExisting = (fetched, existing) => {
+  return omitBy(fetched, it => find(existing, { id: it.id }));
 };
 
 const fetch = ({ state, commit }, { id, repositoryId }) => {
   const action = state.repositoryId === repositoryId ? 'fetch' : 'reset';
   if (action === 'reset') commit('setRepository', repositoryId);
   return api.fetch({ activityId: id }).then(items => {
-    commit(action, filterExistingComment(state.items, items));
+    commit(action, omitExisting(items, state.items));
     commit('commentsFetched', id);
   });
 };

--- a/client/store/modules/comments/actions.js
+++ b/client/store/modules/comments/actions.js
@@ -17,10 +17,7 @@ const subscribe = ({ state, commit }) => {
   if (SSE_CLIENT) SSE_CLIENT.disconnect();
 
   SSE_CLIENT = new SSEClient(`/api/v1${state.$apiUrl}/subscribe`);
-  SSE_CLIENT.subscribe('comment_create', item => {
-    api.setCid(item);
-    commit('sseAdd', item);
-  });
+  SSE_CLIENT.subscribe('comment_create', item => commit('add', item));
   SSE_CLIENT.subscribe('comment_update', item => commit('sseUpdate', item));
   SSE_CLIENT.subscribe('comment_delete', item => commit('sseUpdate', item));
 };

--- a/client/store/modules/comments/actions.js
+++ b/client/store/modules/comments/actions.js
@@ -18,8 +18,8 @@ const subscribe = ({ state, commit }) => {
 
   SSE_CLIENT = new SSEClient(`/api/v1${state.$apiUrl}/subscribe`);
   SSE_CLIENT.subscribe('comment_create', item => {
-    commit('sseAdd', item);
     api.setCid(item);
+    commit('sseAdd', item);
   });
   SSE_CLIENT.subscribe('comment_update', item => commit('sseUpdate', item));
   SSE_CLIENT.subscribe('comment_delete', item => commit('sseUpdate', item));

--- a/client/store/modules/comments/mutations.js
+++ b/client/store/modules/comments/mutations.js
@@ -12,12 +12,6 @@ const commentsFetched = (state, activityId) => {
   Vue.set(state.activitiesFetched, activityId, true);
 };
 
-const sseAdd = (state, comment) => {
-  const { id } = comment;
-  if (find(state.items, { id })) return;
-  Vue.set(state.items, comment._cid, comment);
-};
-
 const sseUpdate = (state, comment) => {
   const existing = find(state.items, { id: comment.id });
   if (!existing) return;
@@ -33,6 +27,5 @@ export {
   save,
   setRepository,
   setEndpoint,
-  sseAdd,
   sseUpdate
 };

--- a/client/store/modules/comments/mutations.js
+++ b/client/store/modules/comments/mutations.js
@@ -1,5 +1,4 @@
 import { fetch, remove, reset, save, setEndpoint } from '../../helpers/mutations';
-import cuid from 'cuid';
 import find from 'lodash/find';
 import pick from 'lodash/pick';
 import Vue from 'vue';
@@ -16,7 +15,6 @@ const commentsFetched = (state, activityId) => {
 const sseAdd = (state, comment) => {
   const { id } = comment;
   if (find(state.items, { id })) return;
-  comment._cid = cuid();
   Vue.set(state.items, comment._cid, comment);
 };
 


### PR DESCRIPTION
I wish to resolve #408 

Bug flow and causes: 
1. SSE event is triggered -> all the suscribers have the new comment in state
2. The user focuses and clicks on the competency -> fetch is triggered
3. Fetch gets the data from the endpoint that includes the comment already put in the state by the SSE
4. Fetch inserts the fetched comments in the state 
5. The comment is then duplicated

Fix:
On the step 3. we scan for the comments that are already in the state and we filter them from the fetch before its triggered. That way we don't put the comments that are already in the state.

@kjuej @underscope Please check if the solution is satisfactionary and where the improvements are to be made. Thx.
