### PR TITLE
Fixed revision URLs

### DIFF
--- a/client/components/repository/Revisions/EntityRevisions.vue
+++ b/client/components/repository/Revisions/EntityRevisions.vue
@@ -28,7 +28,7 @@ import includes from 'lodash/includes';
 import Promise from 'bluebird';
 import TeachingElement from 'components/editor/TeachingElement';
 
-const WITHOUT_STATICS = ['HTML', 'BRIGHTCOVE_VIDEO', 'VIDEO', 'EMBED', 'BREAK'];
+const WITHOUT_STATICS = ['HTML', 'BRIGHTCOVE_VIDEO', 'EMBED', 'BREAK'];
 
 export default {
   name: 'entity-revisions',

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "integration:add": "node -r ./server/script/preflight ./server/script/addIntegration.js",
     "integration:token": "node -r ./server/script/preflight ./server/script/generateIntegrationToken.js",
     "detachDeletedRepos": "node -r ./server/script/preflight ./server/script/detachDeletedRepos.js",
+    "fixRevisionUrls": "node -r ./server/script/preflight ./server/script/fixRevisionUrls.js",
     "start": "node -r ./server/script/preflight ./server",
     "postshrinkwrap": "rewrite-lockfile package-lock.json"
   },

--- a/server/script/fixRevisionUrls.js
+++ b/server/script/fixRevisionUrls.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const get = require('lodash/get');
+const Promise = require('bluebird');
+
+/**
+ * This regex tries to find both possible versions of the url:
+ *  - repository/assests/:content-element-id/:asset-name.ext
+ *  - repository/assests/:asset-name.ext
+ */
+const regex = /(repository\/assets\/(\d+\/)?.+)\?/;
+
+const { Revision, sequelize } = require('../shared/database');
+
+fixRevisionUrls()
+  .then(() => {
+    console.info('Fixed revision URLs.');
+    process.exit(0);
+  })
+  .catch(error => {
+    console.error(error.message);
+    process.exit(1);
+  });
+
+async function fixRevisionUrls() {
+  const transaction = await sequelize.transaction();
+  const revisions = await Revision.findAll({ transaction });
+  await Promise.each(revisions, revision => fixUrl(revision, transaction));
+  return transaction.commit();
+}
+
+function fixUrl(revision, transaction) {
+  const url = get(revision, 'state.data.url');
+  if (!url) return;
+  const assetUrl = url.match(regex);
+  if (!assetUrl) return;
+  let { state } = revision;
+  state = { ...state, data: { ...state.data, url: assetUrl[1] } };
+  return revision.update({ state }, { transaction });
+}

--- a/server/shared/database/index.js
+++ b/server/shared/database/index.js
@@ -63,13 +63,18 @@ function initialize() {
     });
 }
 
+/**
+ * Revision needs to be before Content Element to ensure its hooks are triggered
+ * first. This is a temporary fix until a new system for setting up hooks is in
+ * place.
+ */
 const models = {
   User: defineModel(User),
   Repository: defineModel(Repository),
   RepositoryUser: defineModel(RepositoryUser),
   Activity: defineModel(Activity),
-  ContentElement: defineModel(ContentElement),
   Revision: defineModel(Revision),
+  ContentElement: defineModel(ContentElement),
   Comment: defineModel(Comment)
 };
 


### PR DESCRIPTION
Because of `afterCreate` and `afterUpdate` hooks being added to the Content Element model, the revisions were storing the resolved statics URL. This PR introduces a temporary fix for this issue by switching the order in which the hooks are registered so the Revision hooks are always triggered before the Content Element hooks. The plan is to introduce a system for hooks that will make these hacky solutions unnecessary.

This PR also introduces a script that fixes Revision URLs.