### PR TITLE
Update nodemon config

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -6,6 +6,7 @@
   "ignore": [
     "build",
     "client",
+    "data",
     "dist",
     "*.config.js"
   ],


### PR DESCRIPTION
`data` directory should be ignored by nodemon if it is reserved for filesystem publishing.
