### PR TITLE
Improve HTML meta

### DIFF
--- a/client/components/common/Meta/Html.vue
+++ b/client/components/common/Meta/Html.vue
@@ -19,7 +19,7 @@
 import { quillEditor as QuillEditor } from 'vue-quill-editor';
 import some from 'lodash/some';
 
-const quillOptions = () => ({
+const defaultOptions = () => ({
   modules: {
     toolbar: [
       ['bold', 'italic', 'underline'],
@@ -42,7 +42,7 @@ export default {
     };
   },
   computed: {
-    options: ({ meta }) => ({ ...quillOptions(), ...meta.options })
+    options: ({ meta }) => ({ ...defaultOptions(), ...meta.editorOptions })
   },
   methods: {
     update(quill) {

--- a/client/components/common/Meta/Html.vue
+++ b/client/components/common/Meta/Html.vue
@@ -1,6 +1,8 @@
 <template>
-  <div class="meta-quill-input">
-    <label :for="meta.key">{{ meta.label }}</label>
+  <v-input :class="{ editing }" class="meta-quill-input">
+    <label class="quill-input-label grey lighten-5 px-1" :for="meta.key">
+      {{ meta.label }}
+    </label>
     <div class="editor-wrapper">
       <quill-editor
         :ref="meta.key"
@@ -12,7 +14,7 @@
         :disabled="!editing"
         :class="{ 'meta-quill-disabled': !editing }" />
     </div>
-  </div>
+  </v-input>
 </template>
 
 <script>
@@ -72,12 +74,30 @@ export default {
   position: relative;
   margin: 0 0 20px 0;
   padding: 10px 8px;
+  border: 1px solid rgba(0, 0, 0, 0.6);
+  border-radius: 2px;
   cursor: pointer;
 
-  .meta-quill-disabled {
-    .ql-toolbar.ql-snow {
-      background: #f5f5f5;
-    }
+  &.editing {
+    border-width: 2px;
+  }
+
+  &.editing, &:hover {
+    border-color: currentColor;
+  }
+
+  .quill-input-label {
+    position: absolute;
+    top: -23px;
+    color: rgba(0, 0, 0, 0.6);
+  }
+
+  .editor-wrapper {
+    flex: 1;
+  }
+
+  .ql-toolbar.ql-snow {
+    border-bottom: 1px solid currentColor;
   }
 
   .ql-container {

--- a/client/components/common/Meta/Html.vue
+++ b/client/components/common/Meta/Html.vue
@@ -8,7 +8,7 @@
         @focus="enableEditing"
         @blur="update"
         :name="meta.key"
-        :options="quillOptions"
+        :options="options"
         :disabled="!editing"
         :class="{ 'meta-quill-disabled': !editing }" />
     </div>
@@ -33,14 +33,16 @@ const quillOptions = () => ({
 export default {
   name: 'html-input',
   props: {
-    meta: { type: Object, default: () => ({ value: null }) },
-    quillOptions: { type: Object, default: quillOptions }
+    meta: { type: Object, default: () => ({ value: null }) }
   },
   data() {
     return {
       content: this.meta.value,
       editing: false
     };
+  },
+  computed: {
+    options: ({ meta }) => ({ ...quillOptions(), ...meta.options })
   },
   methods: {
     update(quill) {

--- a/client/components/common/Meta/Html.vue
+++ b/client/components/common/Meta/Html.vue
@@ -50,7 +50,7 @@ export default {
     },
     enableEditing() {
       this.editing = true;
-      const { quill } = this.$refs.html;
+      const { quill } = this.$refs[this.meta.key];
       return this.$nextTick(() => quill.focus());
     },
     getActiveTooltips(quill) {

--- a/client/components/common/Meta/Html.vue
+++ b/client/components/common/Meta/Html.vue
@@ -74,24 +74,20 @@ export default {
 <style lang="scss">
 .meta-quill-input {
   position: relative;
-  margin: 0 0 20px 0;
-  padding: 10px 8px;
+  margin: 0 0 1.25rem 0;
+  padding: 0.625rem 0.5rem;
   border: 1px solid rgba(0, 0, 0, 0.6);
-  border-radius: 2px;
+  border-radius: 0.125rem;
   cursor: pointer;
 
   &.editing {
-    border-width: 2px;
-  }
-
-  &.editing, &:hover {
-    border-color: currentColor;
+    border-width: 0.125rem;
   }
 
   .quill-label {
     position: absolute;
-    top: -21px;
-    font-size: 14px;
+    top: -1.375rem;
+    font-size: 0.875rem;
   }
 
   .editor-wrapper {
@@ -103,12 +99,12 @@ export default {
   }
 
   .ql-container {
-    max-height: 230px;
+    max-height: 15rem;
     overflow: auto;
   }
 
   .ql-tooltip {
-    left: 30px !important;
+    left: 1.875rem !important;
   }
 }
 </style>

--- a/client/components/common/Meta/Html.vue
+++ b/client/components/common/Meta/Html.vue
@@ -1,6 +1,8 @@
 <template>
   <v-input :class="{ editing }" class="meta-quill-input">
-    <label class="quill-input-label grey lighten-5 px-1" :for="meta.key">
+    <label
+      :for="meta.key"
+      class="quill-label v-label theme--light grey lighten-5 px-1">
       {{ meta.label }}
     </label>
     <div class="editor-wrapper">
@@ -86,10 +88,10 @@ export default {
     border-color: currentColor;
   }
 
-  .quill-input-label {
+  .quill-label {
     position: absolute;
-    top: -23px;
-    color: rgba(0, 0, 0, 0.6);
+    top: -21px;
+    font-size: 14px;
   }
 
   .editor-wrapper {


### PR DESCRIPTION
This PR 
- adds the ability to pass Quill editor options (e.g. `toolbar.modules`) to   Quill editor used in HTML meta
- removes unused prop `quillOptions` in favor of `meta.options`
- fixes broken reference

Note: I think we could've made sensible defaults and make it more strict, but this way we don't change existing behavior and add flexibility while we don't deprecate it in favor of Jodit Meta 🤞 

### UI changes
<table>
<tr>
<td><strong>Before</strong></td>
<td><strong>After<strong></td>
</tr>
<tr>
<td>
<img width="442" alt="Screenshot 2020-04-23 at 00 52 21" src="https://user-images.githubusercontent.com/19515679/80042390-23c71d00-84ff-11ea-9718-89dc00fcc6da.png">
</td>
<td>
<img width="446" alt="Screenshot 2020-04-23 at 01 01 06" src="https://user-images.githubusercontent.com/19515679/80042395-26c20d80-84ff-11ea-9024-281eca02033e.png">
</td>
</tr>
</table>
