### PR TITLE
Element toolbar bugfix

### DIFF
--- a/client/components/common/tce-core/ElementToolbar.vue
+++ b/client/components/common/tce-core/ElementToolbar.vue
@@ -50,10 +50,17 @@ export default {
   },
   computed: {
     id: vm => getElementId(vm.element),
-    config: vm => vm.$teRegistry.get(vm.element.type),
+    isQuestion: vm => isQuestion(vm.element.type),
+    config() {
+      const { element, isQuestion } = this;
+      const type = isQuestion
+        ? element.data.type
+        : element.type;
+      return this.$teRegistry.get(type);
+    },
     componentName() {
+      if (this.isQuestion) return;
       const { type } = this.element;
-      if (isQuestion(type)) return;
       return getToolbarName(type);
     },
     componentExists() {


### PR DESCRIPTION
Fixes this (matching question is selected in editor but "Numerical Response" is displayed in toolbar):
![Screenshot 2020-04-30 at 11 28 01](https://user-images.githubusercontent.com/41568437/80695155-cbcb8000-8ad5-11ea-80dc-2e4566181e3e.png)
