### PR TITLE
Fix tce-core element list items key generation

### DIFF
--- a/client/components/common/tce-core/ElementList.vue
+++ b/client/components/common/tce-core/ElementList.vue
@@ -9,7 +9,7 @@
       class="row">
       <div
         v-for="(element, index) in elements"
-        :key="getElementId(element.id)"
+        :key="getElementId(element)"
         @dragstart="dragElementIndex = index"
         @dragend="dragElementIndex = -1"
         :class="`col-xs-${get(element, 'data.width', 12)}`">


### PR DESCRIPTION
This PR:
- Fixes `tce-core`'s `ElementList` passing wrong argument to `getElementId` method when generating list item keys
