### PR TITLE
Introduce add element options on element list and container

### DIFF
--- a/client/components/common/tce-core/ElementList.vue
+++ b/client/components/common/tce-core/ElementList.vue
@@ -26,6 +26,8 @@
       @add="el => $emit('add', el)"
       :include="supportedTypes"
       :activity="activity"
+      :label="addElementOptions.label"
+      :large="addElementOptions.large"
       :position="nextPosition"
       :layout="layout" />
   </div>
@@ -45,7 +47,8 @@ export default {
     supportedTypes: { type: Array, default: null },
     activity: { type: Object, default: null },
     layout: { type: Boolean, default: false },
-    enableAdd: { type: Boolean, default: true }
+    enableAdd: { type: Boolean, default: true },
+    addElementOptions: { type: Object, default: () => ({}) }
   },
   data() {
     return { dragElementIndex: null };

--- a/client/components/common/tce-core/EmbeddedContainer.vue
+++ b/client/components/common/tce-core/EmbeddedContainer.vue
@@ -2,6 +2,7 @@
   <element-list
     @add="addItem"
     @update="reorderItem"
+    :add-element-options="addElementOptions"
     :elements="embeds"
     :supported-types="types"
     :enable-add="!isDisabled && enableAdd">
@@ -33,6 +34,7 @@ export default {
     container: { type: Object, required: true },
     types: { type: Array, default: () => ['JODIT_HTML', 'IMAGE', 'HTML', 'VIDEO'] },
     isDisabled: { type: Boolean, default: false },
+    addElementOptions: { type: Object, default: () => ({}) },
     enableAdd: { type: Boolean, default: true }
   },
   computed: {


### PR DESCRIPTION
### This PR
- [x] Adds `addElementOptions` prop to enable setting `AddElement` button label from `ElementList` and `ElementContainer`.

I went with prop drilling (I still don't approve this), it's KISS, it should be enough to support existing content element system.