### PR TITLE
Set v-carousel height explicitly

### DIFF
--- a/client/components/content-elements/tce-carousel/edit/index.vue
+++ b/client/components/content-elements/tce-carousel/edit/index.vue
@@ -22,7 +22,7 @@
     <v-carousel
       v-else
       v-model="activeItem"
-      :height="`${height}px`"
+      :height="height"
       :show-arrows="false">
       <carousel-item
         v-for="item in items"

--- a/client/components/content-elements/tce-carousel/edit/index.vue
+++ b/client/components/content-elements/tce-carousel/edit/index.vue
@@ -22,6 +22,7 @@
     <v-carousel
       v-else
       v-model="activeItem"
+      :height="`${height}px`"
       :show-arrows="false">
       <carousel-item
         v-for="item in items"


### PR DESCRIPTION
This PR sets `v-carousel` `height` property explicitly thus fixing the issue https://github.com/ExtensionEngine/tailor/issues/532 in which setting the height of an element did nothing, since default `v-carousel` height would be set to `500px`.