### PR TITLE
Improved schema configurability

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ An array of Schema objects.
 Configuration for schema structure nodes (activities). Contains the following
 properties:
 
-- **level** `Number` - The hierarchy level for that particular activity type.
 - **type** `String` - Const for marking activity type.
+- **rootLevel** `Boolean` - Used to define first level (root) activity types
 - **subLevels** `Array<String>` - An array of sub-types.
 - **label** `String` - Display label.
 - **color** `String` - Display color in hexadecimal notation.

--- a/client/components/repository/Outline/Activity.vue
+++ b/client/components/repository/Outline/Activity.vue
@@ -50,7 +50,6 @@
           :key="subActivity._cid"
           v-bind="subActivity"
           :index="childIndex + 1"
-          :level="level + 1"
           :activities="activities"
           class="sub-activity" />
       </draggable>

--- a/client/components/repository/Outline/Activity.vue
+++ b/client/components/repository/Outline/Activity.vue
@@ -80,7 +80,6 @@ export default {
     id: { type: Number, default: null },
     parentId: { type: Number, default: null },
     repositoryId: { type: Number, required: true },
-    level: { type: Number, required: true },
     index: { type: Number, required: true },
     position: { type: Number, required: true },
     type: { type: String, required: true },

--- a/client/components/repository/Outline/Activity.vue
+++ b/client/components/repository/Outline/Activity.vue
@@ -64,7 +64,6 @@ import Draggable from 'vuedraggable';
 import filter from 'lodash/filter';
 import find from 'lodash/find';
 import { isEditable } from 'shared/activities';
-import map from 'lodash/map';
 import OptionsMenu from '../common/ActivityOptions/Menu';
 import OptionsToolbar from '../common/ActivityOptions/Toolbar';
 import reorderMixin from './reorderMixin';
@@ -105,10 +104,9 @@ export default {
     hasSubtypes: vm => !!size(vm.config.subLevels),
     hasChildren: vm => (vm.children.length > 0) && vm.hasSubtypes,
     children() {
-      const level = this.level + 1;
-      const types = map(filter(this.structure, { level }), 'type');
+      const { subLevels } = this.config;
       return filter(this.activities, it => {
-        return this.id && (this.id === it.parentId) && types.includes(it.type);
+        return this.id && (this.id === it.parentId) && subLevels.includes(it.type);
       }).sort((x, y) => x.position - y.position);
     },
     icon() {

--- a/client/components/repository/Outline/OutlineFooter.vue
+++ b/client/components/repository/Outline/OutlineFooter.vue
@@ -20,7 +20,6 @@
 
 <script>
 import CreateDialog from '@/components/repository/common/CreateDialog';
-import filter from 'lodash/filter';
 import last from 'lodash/last';
 import { mapGetters } from 'vuex';
 
@@ -30,7 +29,7 @@ export default {
   },
   computed: {
     ...mapGetters('repository', ['repository', 'structure']),
-    levels: vm => filter(vm.structure, { rootLevel: true }),
+    levels: vm => vm.structure.filter(it => it.rootLevel),
     anchor: vm => last(vm.rootActivities)
   },
   components: { CreateDialog }

--- a/client/components/repository/Outline/OutlineFooter.vue
+++ b/client/components/repository/Outline/OutlineFooter.vue
@@ -30,7 +30,7 @@ export default {
   },
   computed: {
     ...mapGetters('repository', ['repository', 'structure']),
-    levels: vm => filter(vm.structure, { level: 1 }),
+    levels: vm => filter(vm.structure, { rootLevel: true }),
     anchor: vm => last(vm.rootActivities)
   },
   components: { CreateDialog }

--- a/client/components/repository/Outline/index.vue
+++ b/client/components/repository/Outline/index.vue
@@ -75,7 +75,7 @@ export default {
       return !find(this.outlineActivities, it => types.includes(it.type));
     },
     rootActivities() {
-      const types = map(filter(this.structure, { rootLevel: true }), 'type');
+      const types = map(this.structure.filter(it => it.rootLevel), 'type');
       return filter(this.outlineActivities, it => types.includes(it.type) && !it.parentId)
         .sort((x, y) => x.position - y.position);
     },

--- a/client/components/repository/Outline/index.vue
+++ b/client/components/repository/Outline/index.vue
@@ -70,13 +70,13 @@ export default {
     ...mapGetters('repository', ['structure', 'outlineActivities']),
     hasActivities: vm => !!vm.rootActivities.length,
     isFlat() {
-      const types = map(filter(this.structure, { level: 2 }), 'type');
+      const types = map(filter(this.structure, it => !it.rootLevel), 'type');
       if (!types.length) return false;
       return !find(this.outlineActivities, it => types.includes(it.type));
     },
     rootActivities() {
-      const types = map(filter(this.structure, { level: 1 }), 'type');
-      return filter(this.outlineActivities, it => types.includes(it.type))
+      const types = map(filter(this.structure, { rootLevel: true }), 'type');
+      return filter(this.outlineActivities, it => types.includes(it.type) && !it.parentId)
         .sort((x, y) => x.position - y.position);
     },
     filteredActivities() {

--- a/client/components/repository/common/ActivityOptions/Menu.vue
+++ b/client/components/repository/common/ActivityOptions/Menu.vue
@@ -85,11 +85,11 @@ export default {
       const items = [{
         name: 'Copy existing below',
         icon: 'content-copy',
-        action: () => this.setCopyContext()
+        action: () => this.setCopyContext(this.sameLevel)
       }, {
         name: 'Copy existing into',
         icon: 'content-copy',
-        action: () => this.setCopyContext(true)
+        action: () => this.setCopyContext(this.subLevels, true)
       }];
       if (!this.subLevels.length) items.pop();
       return items;
@@ -107,15 +107,17 @@ export default {
   },
   methods: {
     ...mapActions('repository/activities', ['remove']),
-    setCreateContext(levels, addSublevel = false) {
+    setCreateContext(levels, addSublevel) {
+      this.setSupportedLevels(levels, addSublevel);
       this.showCreateDialog = true;
-      this.supportedLevels = levels;
-      this.addSublevel = addSublevel;
     },
-    setCopyContext(addSublevel = false) {
+    setCopyContext(levels, addSublevel) {
+      this.setSupportedLevels(levels, addSublevel);
       this.showCopyDialog = true;
-      this.supportedLevels = this.levels;
-      this.addSublevel = addSublevel;
+    },
+    setSupportedLevels(levels, isSublevel = false) {
+      this.supportedLevels = levels;
+      this.addSublevel = isSublevel;
     },
     delete() {
       const { activity, $route: { name: routeName } } = this;

--- a/client/components/repository/common/ActivityOptions/Menu.vue
+++ b/client/components/repository/common/ActivityOptions/Menu.vue
@@ -73,26 +73,26 @@ export default {
         name: 'Add item below',
         icon: 'arrow-down',
         action: () => this.setCreateContext(this.sameLevel)
-      }, {
+      }];
+      if (!this.subLevels.length) return items;
+      return items.concat({
         name: 'Add item into',
         icon: 'subdirectory-arrow-right',
         action: () => this.setCreateContext(this.subLevels, true)
-      }];
-      if (!this.subLevels.length) items.pop();
-      return items;
+      });
     },
     copyMenuOptions() {
       const items = [{
         name: 'Copy existing below',
         icon: 'content-copy',
         action: () => this.setCopyContext(this.sameLevel)
-      }, {
+      }];
+      if (!this.subLevels.length) return items;
+      return items.concat({
         name: 'Copy existing into',
         icon: 'content-copy',
         action: () => this.setCopyContext(this.subLevels, true)
-      }];
-      if (!this.subLevels.length) items.pop();
-      return items;
+      });
     },
     menuOptions() {
       return [

--- a/client/components/repository/common/ActivityOptions/Toolbar.vue
+++ b/client/components/repository/common/ActivityOptions/Toolbar.vue
@@ -23,8 +23,9 @@
       :repository-id="activity.repositoryId"
       :levels="supportedLevels"
       :anchor="activity"
+      :add-child="addChild"
       :heading="`
-        Add ${isEqual(supportedLevels, subLevels) ? 'into' : 'below'}
+        Add ${addChild ? 'into' : 'below'}
         ${activity.data.name}`" />
   </div>
 </template>
@@ -44,7 +45,7 @@ const getOptions = vm => {
     items.push({
       name: 'Add item into',
       icon: 'subdirectory-arrow-right',
-      action: () => vm.setCreateContext(vm.subLevels)
+      action: () => vm.setCreateContext(vm.subLevels, true)
     });
   }
   if (vm.isEditable) {
@@ -66,16 +67,18 @@ export default {
   },
   data: () => ({
     showCreateDialog: false,
-    supportedLevels: []
+    supportedLevels: [],
+    addChild: false
   }),
   computed: {
     options: vm => getOptions(vm)
   },
   methods: {
     isEqual,
-    setCreateContext(levels) {
+    setCreateContext(levels, addChild) {
       this.supportedLevels = levels;
       this.showCreateDialog = true;
+      this.addChild = addChild;
     }
   },
   components: { CreateDialog }

--- a/client/components/repository/common/ActivityOptions/common.js
+++ b/client/components/repository/common/ActivityOptions/common.js
@@ -1,5 +1,4 @@
 import { mapGetters, mapMutations } from 'vuex';
-import filter from 'lodash/filter';
 import find from 'lodash/find';
 import get from 'lodash/get';
 import { isEditable } from 'shared/activities';
@@ -17,14 +16,14 @@ export default {
     sameLevel() {
       const sameLevelTypes = this.parent
         ? get(find(this.structure, { type: this.parent.type }), 'subLevels', [])
-        : map(filter(this.structure, { rootLevel: true }), 'type');
-      return filter(this.structure, it => sameLevelTypes.includes(it.type));
+        : map(this.structure.filter(it => it.rootLevel), 'type');
+      return this.structure.filter(it => sameLevelTypes.includes(it.type));
     },
     subLevels() {
       if (!this.activity) return [];
       const config = find(this.structure, { type: this.activity.type });
       const subLevels = get(config, 'subLevels', []);
-      return filter(this.structure, it => subLevels.includes(it.type));
+      return this.structure.filter(it => subLevels.includes(it.type));
     }
   },
   methods: {

--- a/client/components/repository/common/ActivityOptions/common.js
+++ b/client/components/repository/common/ActivityOptions/common.js
@@ -2,7 +2,6 @@ import { mapGetters, mapMutations } from 'vuex';
 import find from 'lodash/find';
 import get from 'lodash/get';
 import { isEditable } from 'shared/activities';
-import map from 'lodash/map';
 import selectActivity from '@/components/repository/common/selectActivity';
 import uniqBy from 'lodash/uniqBy';
 

--- a/client/components/repository/common/ActivityOptions/common.js
+++ b/client/components/repository/common/ActivityOptions/common.js
@@ -14,9 +14,9 @@ export default {
     isEditable: vm => isEditable(vm.activity.type),
     levels: vm => uniqBy(vm.sameLevel.concat(vm.subLevels), 'type'),
     sameLevel() {
-      const sameLevelTypes = this.parent
-        ? get(find(this.structure, { type: this.parent.type }), 'subLevels', [])
-        : map(this.structure.filter(it => it.rootLevel), 'type');
+      if (!this.parent) this.structure.filter(it => it.rootLevel);
+      const parentConfig = find(this.structure, { type: this.parent.type });
+      const sameLevelTypes = get(parentConfig, 'subLevels', []);
       return this.structure.filter(it => sameLevelTypes.includes(it.type));
     },
     subLevels() {

--- a/client/components/repository/common/ActivityOptions/common.js
+++ b/client/components/repository/common/ActivityOptions/common.js
@@ -5,6 +5,7 @@ import get from 'lodash/get';
 import { isEditable } from 'shared/activities';
 import map from 'lodash/map';
 import selectActivity from '@/components/repository/common/selectActivity';
+import uniqBy from 'lodash/uniqBy';
 
 export default {
   mixins: [selectActivity],
@@ -12,11 +13,11 @@ export default {
     ...mapGetters('repository', ['structure', 'activities']),
     parent: vm => find(vm.activities, { id: vm.activity.parentId }),
     isEditable: vm => isEditable(vm.activity.type),
-    levels: vm => vm.sameLevel.concat(vm.subLevels),
+    levels: vm => uniqBy(vm.sameLevel.concat(vm.subLevels), 'type'),
     sameLevel() {
       const sameLevelTypes = this.parent
         ? get(find(this.structure, { type: this.parent.type }), 'subLevels', [])
-        : map(filter(this.structure, { level: 1 }), 'type');
+        : map(filter(this.structure, { rootLevel: true }), 'type');
       return filter(this.structure, it => sameLevelTypes.includes(it.type));
     },
     subLevels() {

--- a/client/components/repository/common/ActivityOptions/common.js
+++ b/client/components/repository/common/ActivityOptions/common.js
@@ -14,7 +14,7 @@ export default {
     isEditable: vm => isEditable(vm.activity.type),
     levels: vm => uniqBy(vm.sameLevel.concat(vm.subLevels), 'type'),
     sameLevel() {
-      if (!this.parent) this.structure.filter(it => it.rootLevel);
+      if (!this.parent) return this.structure.filter(it => it.rootLevel);
       const parentConfig = find(this.structure, { type: this.parent.type });
       const sameLevelTypes = get(parentConfig, 'subLevels', []);
       return this.structure.filter(it => sameLevelTypes.includes(it.type));

--- a/client/components/repository/common/CreateDialog/TypeSelect.vue
+++ b/client/components/repository/common/CreateDialog/TypeSelect.vue
@@ -7,6 +7,7 @@
     :error-messages="vErrors.collect('type')"
     :disabled="disabled"
     item-value="type"
+    item-text="label"
     name="type"
     label="Type"
     outlined

--- a/client/components/repository/common/CreateDialog/TypeSelect.vue
+++ b/client/components/repository/common/CreateDialog/TypeSelect.vue
@@ -3,24 +3,16 @@
     v-validate="{ required: true }"
     @change="$emit('input', $event)"
     :value="value"
-    :items="groupedOptions"
+    :items="options"
     :error-messages="vErrors.collect('type')"
     :disabled="disabled"
-    item-text="label"
     item-value="type"
     name="type"
     label="Type"
     outlined
     class="required">
     <template slot="item" slot-scope="{ item }">
-      <div v-if="item.group" class="pr-5">
-        <v-icon color="grey" size="16" class="pr-1">mdi-folder-open-outline</v-icon>
-        <span class="pt-2">{{ item.group }}</span>
-      </div>
-      <div
-        v-else
-        :class="{ 'pl-6': item.level > rootLevel }"
-        class="black--text">
+      <div class="black--text">
         <v-icon size="16" color="grey" class="pr-1">
           mdi-{{ hasSubtypes(item) ? 'folder' : 'file-document-box-outline' }}
         </v-icon>
@@ -31,9 +23,7 @@
 </template>
 
 <script>
-import partition from 'lodash/partition';
 import size from 'lodash/size';
-import sortedUniq from 'lodash/sortedUniq';
 import { withValidation } from 'utils/validation';
 
 export default {
@@ -43,16 +33,6 @@ export default {
     value: { type: String, default: null },
     options: { type: Array, required: true },
     disabled: { type: Boolean, default: false }
-  },
-  computed: {
-    levels: vm => sortedUniq(vm.options.map(it => it.level)),
-    rootLevel: vm => vm.levels[0],
-    groupedOptions() {
-      const { options, rootLevel } = this;
-      const [sameLevel, subLevel] = partition(options, { level: rootLevel });
-      if (!subLevel.length) return sameLevel;
-      return [...sameLevel, { group: 'Sublevels', disabled: true }, ...subLevel];
-    }
   },
   methods: {
     hasSubtypes: item => !!size(item.subLevels)

--- a/client/components/repository/common/CreateDialog/index.vue
+++ b/client/components/repository/common/CreateDialog/index.vue
@@ -24,7 +24,7 @@
     </template>
     <template v-slot:actions>
       <v-btn @click="visible = false" text>Cancel</v-btn>
-      <v-btn @click="create" color="primary" text>Create</v-btn>
+      <v-btn @click="create" color="primary darken-1" text>Create</v-btn>
     </template>
   </tailor-dialog>
 </template>
@@ -32,7 +32,6 @@
 <script>
 import { mapActions, mapGetters } from 'vuex';
 import { getActivityMetadata } from 'shared/activities';
-import { isSameLevel } from 'utils/activity';
 import MetaInput from 'components/common/Meta';
 import TailorDialog from '@/components/common/TailorDialog';
 import TypeSelect from './TypeSelect';
@@ -51,6 +50,7 @@ export default {
     repositoryId: { type: Number, required: true },
     levels: { type: Array, required: true },
     anchor: { type: Object, default: null },
+    addChild: { type: Boolean, default: false },
     heading: { type: String, default: '' },
     showActivator: { type: Boolean, default: false },
     activatorLabel: { type: String, default: '' },
@@ -82,7 +82,7 @@ export default {
       if (!isValid) return;
       const { activity, anchor } = this;
       if (anchor) {
-        activity.parentId = isSameLevel(activity, anchor)
+        activity.parentId = !this.addChild
           ? anchor.parentId
           : anchor.id;
       }

--- a/client/components/repository/common/CreateDialog/index.vue
+++ b/client/components/repository/common/CreateDialog/index.vue
@@ -82,9 +82,7 @@ export default {
       if (!isValid) return;
       const { activity, anchor } = this;
       if (anchor) {
-        activity.parentId = !this.addChild
-          ? anchor.parentId
-          : anchor.id;
+        activity.parentId = this.addChild ? anchor.id : anchor.parentId;
       }
       activity.position = this.calculateInsertPosition(activity, anchor);
       const item = await this.save({ ...activity });

--- a/client/components/repository/common/Sidebar/Header.vue
+++ b/client/components/repository/common/Sidebar/Header.vue
@@ -21,7 +21,7 @@
       activator-label="Add into"
       activator-color="blue-grey darken-3"
       activator-icon="mdi-folder-plus-outline"
-      show-activator />
+      add-child show-activator />
     <publishing
       v-if="isAdmin || isRepositoryAdmin"
       :activity="activity"

--- a/client/components/system-settings/StructureTypes.vue
+++ b/client/components/system-settings/StructureTypes.vue
@@ -40,7 +40,7 @@ export default {
   computed: {
     schemas() {
       return SCHEMAS.map(({ name: label, structure }) => {
-        const roots = structure.filter(it => it.level === 1);
+        const roots = structure.filter(it => it.rootLevel);
         const children = roots.reduce((acc, { type }) => {
           acc.push(buildTree(type, structure));
           return acc;

--- a/client/components/system-settings/StructureTypes.vue
+++ b/client/components/system-settings/StructureTypes.vue
@@ -32,7 +32,7 @@ const buildTree = (type, structure) => {
   const { subLevels, ...leaf } = structure.find(it => it.type === type);
   if (!subLevels.length) return { id, ...leaf };
   const children = without(subLevels, type).map(type => buildTree(type, structure));
-  return { id, children, ...leaf, recursive: subLevels.includes(type) };
+  return { id, children, recursive: subLevels.includes(type), ...leaf };
 };
 
 export default {

--- a/client/components/system-settings/StructureTypes.vue
+++ b/client/components/system-settings/StructureTypes.vue
@@ -16,6 +16,7 @@
         <v-icon color="blue-grey darken-3">
           {{ open ? 'mdi-folder-open' : 'mdi-folder' }}
         </v-icon>
+        <v-icon v-if="item.recursive" color="primary darken-2">mdi-replay</v-icon>
       </template>
     </v-treeview>
   </div>
@@ -24,13 +25,14 @@
 <script>
 import cuid from 'cuid';
 import { SCHEMAS } from 'shared/activities';
+import without from 'lodash/without';
 
 const buildTree = (type, structure) => {
   const id = cuid();
   const { subLevels, ...leaf } = structure.find(it => it.type === type);
   if (!subLevels.length) return { id, ...leaf };
-  const children = subLevels.map(type => buildTree(type, structure));
-  return { id, children, ...leaf };
+  const children = without(subLevels, type).map(type => buildTree(type, structure));
+  return { id, children, ...leaf, recursive: subLevels.includes(type) };
 };
 
 export default {

--- a/client/store/modules/repository/activities/getters.js
+++ b/client/store/modules/repository/activities/getters.js
@@ -1,8 +1,7 @@
 import {
   getDescendants as getDeepChildren,
   getOutlineChildren,
-  getAncestors as getParents,
-  isSameLevel
+  getAncestors as getParents
 } from 'utils/activity';
 import calculatePosition from 'utils/calculatePosition';
 import find from 'lodash/find';
@@ -37,7 +36,9 @@ export const calculateInsertPosition = state => {
   return (activity, anchor) => {
     const items = getOutlineChildren(state.items, activity.parentId);
     const newPosition = anchor ? findIndex(items, { id: anchor.id }) : 1;
-    const isFirstChild = !anchor || !isSameLevel(activity, anchor) || newPosition === -1;
+    const isFirstChild = !anchor ||
+      (activity.parentId !== anchor.parentId) ||
+      newPosition === -1;
     const context = { items, newPosition, isFirstChild, insert: true };
     return calculatePosition(context);
   };

--- a/client/store/modules/repository/activities/getters.js
+++ b/client/store/modules/repository/activities/getters.js
@@ -38,7 +38,7 @@ export const calculateInsertPosition = state => {
     const newPosition = anchor ? findIndex(items, { id: anchor.id }) : 1;
     const isFirstChild = !anchor ||
       (activity.parentId !== anchor.parentId) ||
-      newPosition === -1;
+      (newPosition === -1);
     const context = { items, newPosition, isFirstChild, insert: true };
     return calculatePosition(context);
   };

--- a/client/utils/activity.js
+++ b/client/utils/activity.js
@@ -43,10 +43,6 @@ export function getAncestors(activities, activity) {
   return [...ancestors, parent];
 }
 
-export function isSameLevel(activityX, activityY) {
-  return getLevel(activityX.type).level === getLevel(activityY.type).level;
-}
-
 export function toTreeFormat(activities, targetLevels, parentId = null, level = 1) {
   return getOutlineChildren(activities, parentId).map(activity => ({
     ...activity,

--- a/client/utils/revision.js
+++ b/client/utils/revision.js
@@ -43,7 +43,7 @@ function describeActivityRevision(rev, activity) {
   const typeLabel = getActivityTypeLabel(rev.state);
   const action = getAction(rev.operation);
   const activityConfig = getLevel(rev.state.type);
-  const containerContext = activityConfig.level !== 1
+  const containerContext = !activityConfig.rootLevel
     ? getContainerContext(activity)
     : '';
   return `${action} ${name} ${lower(typeLabel)} ${containerContext}`;

--- a/client/utils/revision.js
+++ b/client/utils/revision.js
@@ -43,9 +43,9 @@ function describeActivityRevision(rev, activity) {
   const typeLabel = getActivityTypeLabel(rev.state);
   const action = getAction(rev.operation);
   const activityConfig = getLevel(rev.state.type);
-  const containerContext = !activityConfig.rootLevel
-    ? getContainerContext(activity)
-    : '';
+  const containerContext = activityConfig.rootLevel
+    ? ''
+    : getContainerContext(activity);
   return `${action} ${name} ${lower(typeLabel)} ${containerContext}`;
 }
 

--- a/config/shared/activities-rc.js
+++ b/config/shared/activities-rc.js
@@ -19,8 +19,8 @@ const SCHEMAS = [{
   name: 'Sample course',
   meta: [],
   structure: [{
-    level: 1,
     type: 'COMPETENCY',
+    rootLevel: true,
     subLevels: ['OBJECTIVE'],
     label: 'Competency',
     color: '#42A5F5',
@@ -38,7 +38,6 @@ const SCHEMAS = [{
       validate: { max: 250 }
     }]
   }, {
-    level: 2,
     type: 'OBJECTIVE',
     subLevels: ['TOPIC'],
     label: 'Learning Objective',
@@ -57,7 +56,6 @@ const SCHEMAS = [{
       validate: { required: false, max: 250 }
     }]
   }, {
-    level: 3,
     type: 'TOPIC',
     label: 'Topic',
     color: '#EC407A',

--- a/config/shared/schema-validation.js
+++ b/config/shared/schema-validation.js
@@ -29,11 +29,11 @@ const schema = yup.object().shape({
   name: yup.string().min(2).max(200).required(),
   meta,
   structure: yup.array().of(yup.object().shape({
-    level: yup.number().integer().min(1).max(10).required(),
     type: activityType.required(),
+    rootLevel: yup.boolean(),
+    subLevels: yup.array().of(activityType),
     label: yup.string().min(2).max(100).required(),
     color: yup.string().matches(/^#(?:[0-9a-fA-F]{3}){1,2}$/).required(),
-    subLevels: yup.array().of(activityType),
     isObjective: yup.boolean(),
     contentContainers: yup.array().of(activityType),
     hasAssessments: yup.boolean(),


### PR DESCRIPTION
This PR improves schema configurability:
- Adds the ability for the same type to exist on multiple levels
- Type recursion (type can be nested within itself/support for dir like structure)

🚨 Breaking changes
1. Omited level property from activity configuration
2. Added `rootLevel` flag to activity configuration to signalize root activities


Example schema:

```javascript
const ACTIVITY_TYPE = {
  MODULE: 'MODULE',
  LESSON: 'LESSON',
  CONTENT_PAGE: 'CONTENT_PAGE'
}

const MODULE = {
  type: ACTIVITY_TYPE.MODULE,
  rootLevel: true,
  label: 'Module',
  color: '#5187C7',
  subLevels: [
    ACTIVITY_TYPE.MODULE,
    ACTIVITY_TYPE.LESSON,
    ACTIVITY_TYPE.CONTENT_PAGE
  ]
};

const LESSON = {
  type: ACTIVITY_TYPE.LESSON,
  rootLevel: true,
  label: 'Lesson',
  color: '#606F7B',
  subLevels: [
    ACTIVITY_TYPE.CONTENT_PAGE
  ]
};

const CONTENT_PAGE = {
  type: ACTIVITY_TYPE.CONTENT_PAGE,
  rootLevel: true,
  label: 'Content page',
  color: '#08A9AD'
};

const TEST_SCHEMA = {
  id: 'TEST_SCHEMA',
  name: 'Test Course',
  structure: [
    MODULE,
    LESSON,
    CONTENT_PAGE
  ]
};

module.exports = {
  SCHEMAS: [TEST_SCHEMA]
};

```