### PR TITLE
X-Frame-Options bugfix

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -25,7 +25,10 @@ app.use(bodyParser.json({ limit: '50mb' }));
 app.use(auth.initialize());
 app.use(origin());
 app.use(express.static(path.join(__dirname, '../dist/')));
-if (STORAGE_PATH) app.use(express.static(STORAGE_PATH));
+if (STORAGE_PATH) {
+  const setHeaders = res => res.removeHeader('X-Frame-Options');
+  app.use(express.static(STORAGE_PATH, { setHeaders }));
+}
 
 // Mount main router.
 app.use('/api/v1', requestLogger, router);


### PR DESCRIPTION
Removes `X-Frame-Options` header previously set by `helmet` for FS hosted assets.

Assets within `<frame>`, `<iframe>`, `<embed>` or `<object>` are now rendered correctly.