### PR TITLE
Send activity link with discussion notification

### DIFF
--- a/server/comment/hooks.js
+++ b/server/comment/hooks.js
@@ -39,7 +39,9 @@ async function sendEmailNotification(comment, db) {
   });
   const { author, repository, activity } = comment;
   const data = {
+    repositoryId: repository.id,
     repository: repository.name,
+    activityId: activity.id,
     topic: activity.data.name,
     author: author.profile,
     ...pick(comment, ['id', 'content', 'createdAt'])

--- a/server/comment/hooks.js
+++ b/server/comment/hooks.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { broadcast, events } = require('./channel');
+const { getLevel } = require('../../config/shared/activities');
 const mail = require('../shared/mail');
 const map = require('lodash/map');
 const pick = require('lodash/pick');
@@ -42,6 +43,7 @@ async function sendEmailNotification(comment, db) {
     repositoryId: repository.id,
     repositoryName: repository.name,
     activityId: activity.id,
+    activityLabel: getLevel(activity.type).label,
     topic: activity.data.name,
     author: author.profile,
     ...pick(comment, ['id', 'content', 'createdAt'])

--- a/server/comment/hooks.js
+++ b/server/comment/hooks.js
@@ -40,7 +40,7 @@ async function sendEmailNotification(comment, db) {
   const { author, repository, activity } = comment;
   const data = {
     repositoryId: repository.id,
-    repository: repository.name,
+    repositoryName: repository.name,
     activityId: activity.id,
     topic: activity.data.name,
     author: author.profile,

--- a/server/shared/mail/index.js
+++ b/server/shared/mail/index.js
@@ -19,7 +19,7 @@ const templatesDir = path.join(__dirname, './templates/');
 
 const resetUrl = token => urlJoin(origin, '/#/reset-password/', token);
 const activityUrl = (repositoryId, activityId) =>
-  urlJoin(origin, '/#/repository', repositoryId, `?activityId=${activityId}`);
+  urlJoin(origin, '/#/repository', `${repositoryId}?activityId=${activityId}`);
 
 module.exports = {
   send,
@@ -65,7 +65,7 @@ function resetPassword(user, token) {
 
 function sendCommentNotification(users, comment) {
   const { repositoryId, activityId } = comment;
-  const href = activityUrl(repositoryId.toString(), activityId.toString());
+  const href = activityUrl(repositoryId, activityId);
   const recipients = users.concat(',');
   const data = { href, ...comment };
   const html = renderHtml(path.join(templatesDir, 'comment.mjml'), data);

--- a/server/shared/mail/index.js
+++ b/server/shared/mail/index.js
@@ -18,6 +18,8 @@ const send = promisify(server.send.bind(server));
 const templatesDir = path.join(__dirname, './templates/');
 
 const resetUrl = token => urlJoin(origin, '/#/reset-password/', token);
+const activityUrl = (repositoryId, activityId) =>
+  urlJoin(origin, '/#/repository', repositoryId, `?activityId=${activityId}`);
 
 module.exports = {
   send,
@@ -62,9 +64,12 @@ function resetPassword(user, token) {
 }
 
 function sendCommentNotification(users, comment) {
+  const { repositoryId, activityId } = comment;
+  const href = activityUrl(repositoryId.toString(), activityId.toString());
   const recipients = users.concat(',');
-  const html = renderHtml(path.join(templatesDir, 'comment.mjml'), comment);
-  const text = renderText(path.join(templatesDir, 'comment.txt'), comment);
+  const data = { href, ...comment };
+  const html = renderHtml(path.join(templatesDir, 'comment.mjml'), data);
+  const text = renderText(path.join(templatesDir, 'comment.txt'), data);
   logger.info({ recipients, sender: from }, '📧  Sending notification email to:', recipients);
   return send({
     from,

--- a/server/shared/mail/index.js
+++ b/server/shared/mail/index.js
@@ -74,7 +74,7 @@ function sendCommentNotification(users, comment) {
   return send({
     from,
     to: recipients,
-    subject: `${comment.author.label} left a comment on ${comment.repository}`,
+    subject: `${comment.author.label} left a comment on ${comment.repositoryName}`,
     text,
     attachment: [{ data: html, alternative: true }]
   });

--- a/server/shared/mail/templates/comment.mjml
+++ b/server/shared/mail/templates/comment.mjml
@@ -35,10 +35,10 @@
           padding-left="0"
           color="#444"
           font-size="16px">
-          Open the activity by clicking the button below:
+          Open the {{activityLabel}} by clicking the button below:
         </mj-text>
         <mj-button mj-class="ctaButton" href="{{href}}">
-          Open activity
+          View {{activityLabel}}
         </mj-button>
         <mj-text
           mj-class="content"

--- a/server/shared/mail/templates/comment.mjml
+++ b/server/shared/mail/templates/comment.mjml
@@ -11,7 +11,7 @@
           padding-left="0"
           color="#444"
           font-size="16px">
-          <b>{{author.label}}</b> left a comment on {{repository}}, {{topic}}.
+          <b>{{author.label}}</b> left a comment on {{repositoryName}}, {{topic}}.
         </mj-text>
       </mj-column>
     </mj-section>

--- a/server/shared/mail/templates/comment.mjml
+++ b/server/shared/mail/templates/comment.mjml
@@ -35,7 +35,7 @@
           padding-left="0"
           color="#444"
           font-size="16px">
-          Open the {{activityLabel}} by clicking the button below:
+          View the {{activityLabel}} by clicking the button below:
         </mj-text>
         <mj-button mj-class="ctaButton" href="{{href}}">
           View {{activityLabel}}

--- a/server/shared/mail/templates/comment.mjml
+++ b/server/shared/mail/templates/comment.mjml
@@ -3,11 +3,9 @@
   <mj-body padding="10px">
     <mj-include path="./components/header.mjml"/>
     <mj-section
-      padding="10px 10px 20px 10px"
+      padding="0 10px"
       text-align="left">
-      <mj-column
-        padding-bottom="15px"
-        border-bottom="1px solid #ccc">
+      <mj-column border-bottom="1px solid #ccc">
         <mj-text
           mj-class="content"
           padding-left="0"
@@ -17,7 +15,7 @@
         </mj-text>
       </mj-column>
     </mj-section>
-    <mj-section padding="0 10px">
+    <mj-section padding="20px 10px">
       <mj-column
         background-color="#f1f1f1"
         border-radius="8px">
@@ -27,6 +25,34 @@
           color="#444"
           font-size="16px">
           {{content}}
+        </mj-text>
+      </mj-column>
+    </mj-section>
+    <mj-section padding="0 10px">
+      <mj-column border-top="1px solid #ccc">
+        <mj-text
+          mj-class="content"
+          padding-left="0"
+          color="#444"
+          font-size="16px">
+          Open the activity by clicking the button below:
+        </mj-text>
+        <mj-button mj-class="ctaButton" href="{{href}}">
+          Open activity
+        </mj-button>
+        <mj-text
+          mj-class="content"
+          padding-left="0"
+          color="#444"
+          font-size="16px">
+          Or copy and paste this URL into your browser:
+        </mj-text>
+        <mj-text
+          mj-class="content"
+          padding-left="0"
+          color="#444"
+          font-size="16px">
+          <a href="{{href}}">{{href}}</a>
         </mj-text>
       </mj-column>
     </mj-section>

--- a/server/shared/mail/templates/comment.txt
+++ b/server/shared/mail/templates/comment.txt
@@ -5,4 +5,10 @@ Tailor
 
 {{content}}
 
+Open the activity by clicking the URL below:
+
+{{href}}
+
+Or copy and paste this URL into your browser.
+
 -------------------------------------------------

--- a/server/shared/mail/templates/comment.txt
+++ b/server/shared/mail/templates/comment.txt
@@ -5,7 +5,7 @@ Tailor
 
 {{content}}
 
-Open the activity by clicking the URL below:
+Open {{activityLabel}} by clicking the URL below:
 
 {{href}}
 

--- a/server/shared/mail/templates/comment.txt
+++ b/server/shared/mail/templates/comment.txt
@@ -5,7 +5,7 @@ Tailor
 
 {{content}}
 
-Open {{activityLabel}} by clicking the URL below:
+View {{activityLabel}} by clicking the URL below:
 
 {{href}}
 

--- a/server/shared/mail/templates/comment.txt
+++ b/server/shared/mail/templates/comment.txt
@@ -1,7 +1,7 @@
 Tailor
 =================================================
 
-{{author.label}} left a comment on {{repository}}, {{topic}}:
+{{author.label}} left a comment on {{repositoryName}}, {{topic}}:
 
 {{content}}
 


### PR DESCRIPTION
As a part of issue https://github.com/ExtensionEngine/tailor/issues/516 this PR: 
- Updates comment email templates to display activity link
![Screen Shot 2020-08-19 at 9 52 45 AM](https://user-images.githubusercontent.com/7149531/90607618-bf447200-e201-11ea-9712-f8fc4bb272ca.png)

- Updates comment hook to pass required arguments
