### PR TITLE
Refactor `clean-out-dir` poi plugin

### DIFF
--- a/build/plugins/clean-out-dir.js
+++ b/build/plugins/clean-out-dir.js
@@ -4,15 +4,22 @@ exports.name = 'clean-out-dir';
 
 /**
  * @param {import('poi')} api
+ * @returns {Boolean}
+ */
+exports.when = api => {
+  const { isProd, config } = api;
+  return isProd && config.output && config.output.clean;
+};
+
+/**
+ * @param {import('poi')} api
  * @param {import('clean-webpack-plugin').Options} options
  */
 exports.apply = (api, options = {}) => {
   api.hook('createWebpackChain', config => {
-    if (!api.isProd || !api.config.output.clean) return;
-    const { CleanWebpackPlugin } = require('clean-webpack-plugin');
     options.verbose = Boolean(api.args.options.debug);
     config
       .plugin('clean-out-dir')
-      .use(CleanWebpackPlugin, [options]);
+      .use(require('clean-webpack-plugin').CleanWebpackPlugin, [options]);
   });
 };


### PR DESCRIPTION
Prevent `clean-out-dir` from loading by leveraging the `plugin.when` predicate. 🏄 