### PR TITLE
Set min attribute on exam input

### DIFF
--- a/client/components/content-containers/tcc-exam/edit/AssessmentGroup.vue
+++ b/client/components/content-containers/tcc-exam/edit/AssessmentGroup.vue
@@ -12,6 +12,7 @@
             v-model.number="timeLimit"
             @keydown="e => ['e', '+', '-', '.'].includes(e.key) && e.preventDefault()"
             :error-messages="errors"
+            min="0"
             name="timeLimit"
             hint="Time limit (minutes)"
             type="number"


### PR DESCRIPTION
This PR:

Solves https://github.com/ExtensionEngine/tailor/issues/138 by setting the `min` attribute to `0`, thus disallowing the input to be a negative number.