### PR TITLE
Snackbar bugfix

### DIFF
--- a/client/plugins/vuetify-snackbar/Snackbar.vue
+++ b/client/plugins/vuetify-snackbar/Snackbar.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-snackbar v-model="snackbar" v-bind="context" multi-line>
+  <v-snackbar v-model="snackbar" v-bind="context" absolute multi-line>
     {{ context.message }}
     <v-btn
       @click="close"

--- a/client/plugins/vuetify-snackbar/Snackbar.vue
+++ b/client/plugins/vuetify-snackbar/Snackbar.vue
@@ -48,3 +48,9 @@ function Deferred() {
   this.promise = new Promise(resolve => (this.resolve = resolve));
 }
 </script>
+
+<style lang="scss" scoped>
+.v-snack {
+  z-index: 9999;
+}
+</style>


### PR DESCRIPTION
![Screenshot 2020-10-13 at 15 02 29](https://user-images.githubusercontent.com/41568437/95869943-37479800-0d6c-11eb-8289-3e9f3b5a83f9.png)

Caused by: https://github.com/vuetifyjs/vuetify/blob/v2.3.12/packages/vuetify/src/components/VSnackbar/VSnackbar.ts#L105