### PR TITLE
Add required class to all inputs with required rule

### DIFF
--- a/client/components/auth/ForgotPassword.vue
+++ b/client/components/auth/ForgotPassword.vue
@@ -24,7 +24,8 @@
           label="Email"
           placeholder="Email"
           prepend-inner-icon="mdi-email-outline"
-          outlined />
+          outlined
+          class="required" />
       </validation-provider>
       <div class="d-flex">
         <v-btn @click="$router.go(-1)" tag="a" text class="px-1">

--- a/client/components/auth/Login.vue
+++ b/client/components/auth/Login.vue
@@ -27,7 +27,7 @@
           autocomplete="username"
           prepend-inner-icon="mdi-email-outline"
           outlined
-          class="mb-1" />
+          class="required mb-1" />
       </validation-provider>
       <validation-provider
         v-slot="{ errors }"
@@ -42,7 +42,8 @@
           placeholder="Password"
           prepend-inner-icon="mdi-lock-outline"
           autocomplete="current-password"
-          outlined />
+          outlined
+          class="required" />
       </validation-provider>
       <div class="d-flex">
         <v-spacer />

--- a/client/components/auth/ResetPassword.vue
+++ b/client/components/auth/ResetPassword.vue
@@ -26,7 +26,7 @@
           placeholder="Password"
           prepend-inner-icon="mdi-lock"
           outlined
-          class="mb-1" />
+          class="required mb-1" />
       </validation-provider>
       <validation-provider
         v-slot="{ errors }"
@@ -41,7 +41,8 @@
           label="Re-enter password"
           placeholder="Password confirmation"
           prepend-inner-icon="mdi-lock-outline"
-          outlined />
+          outlined
+          class="required" />
       </validation-provider>
       <v-btn
         type="submit"

--- a/client/components/catalog/Add.vue
+++ b/client/components/catalog/Add.vue
@@ -49,6 +49,7 @@
                 v-model="repository.schema"
                 :items="schemas"
                 :error-messages="errors"
+                :class="{ required: isCreate }"
                 item-value="id"
                 item-text="name"
                 label="Schema"
@@ -65,6 +66,7 @@
                 v-model="archive"
                 :error-messages="errors"
                 :clearable="false"
+                :class="{ required: !isCreate }"
                 label="Archive"
                 prepend-icon=""
                 prepend-inner-icon="mdi-paperclip"
@@ -83,7 +85,8 @@
             name="repositoryName"
             label="Name"
             placeholder="Enter name..."
-            outlined />
+            outlined
+            class="required" />
         </validation-provider>
         <validation-provider
           v-slot="{ errors }"
@@ -94,7 +97,8 @@
             :error-messages="errors"
             label="Description"
             placeholder="Enter description..."
-            outlined />
+            outlined
+            class="required" />
         </validation-provider>
         <div class="d-flex justify-end">
           <v-btn @click="hide" :disabled="showLoader" text>Cancel</v-btn>

--- a/client/components/catalog/Card/Tags/AddTag.vue
+++ b/client/components/catalog/Card/Tags/AddTag.vue
@@ -23,7 +23,8 @@
             :items="availableTags"
             :error-messages="errors"
             label="Select a tag or add a new one"
-            outlined />
+            outlined
+            class="required" />
         </validation-provider>
         <div class="d-flex justify-end">
           <v-btn @click="hide" text>Cancel</v-btn>

--- a/client/components/content-elements/tce-carousel/edit/Toolbar.vue
+++ b/client/components/content-elements/tce-carousel/edit/Toolbar.vue
@@ -22,7 +22,7 @@
           placeholder="Height..."
           prepend-icon="mdi-resize"
           filled dense
-          class="mt-2 ml-5" />
+          class="required mt-2 ml-5" />
       </validation-provider>
     </v-toolbar-items>
   </v-toolbar>

--- a/client/components/content-elements/tce-embed/edit/Toolbar.vue
+++ b/client/components/content-elements/tce-embed/edit/Toolbar.vue
@@ -21,7 +21,7 @@
             placeholder="Height..."
             prepend-icon="mdi-resize"
             dense filled
-            class="height-input" />
+            class="required height-input" />
         </validation-provider>
         <validation-provider
           v-slot="{ errors }"

--- a/client/components/meta-inputs/meta-input/Edit.vue
+++ b/client/components/meta-inputs/meta-input/Edit.vue
@@ -3,7 +3,8 @@
     ref="validator"
     v-slot="{ errors }"
     :name="lowerCase(meta.label)"
-    :rules="validationRules">
+    :rules="validationRules"
+    slim>
     <v-text-field
       v-model="value"
       @change="onChange"

--- a/client/components/meta-inputs/meta-textarea/Edit.vue
+++ b/client/components/meta-inputs/meta-textarea/Edit.vue
@@ -3,7 +3,8 @@
     ref="validator"
     v-slot="{ errors }"
     :name="lowerCase(meta.label)"
-    :rules="validationRules">
+    :rules="validationRules"
+    slim>
     <v-textarea
       v-model="value"
       @change="onChange"

--- a/client/components/repository/Settings/CloneModal.vue
+++ b/client/components/repository/Settings/CloneModal.vue
@@ -18,7 +18,7 @@
             label="Name"
             placeholder="Enter name..."
             outlined
-            class="mb-4" />
+            class="required mb-4" />
         </validation-provider>
         <validation-provider
           v-slot="{ errors }"
@@ -31,7 +31,7 @@
             label="Description"
             placeholder="Enter description..."
             outlined
-            class="mb-4" />
+            class="required mb-4" />
         </validation-provider>
         <div class="d-flex justify-end">
           <v-btn @click="close" :disabled="inProgress" text>Cancel</v-btn>

--- a/client/components/repository/Settings/UserManagement/AddUserDialog.vue
+++ b/client/components/repository/Settings/UserManagement/AddUserDialog.vue
@@ -31,7 +31,8 @@
             :error-messages="errors"
             label="Email"
             placeholder="Enter email..."
-            outlined />
+            outlined
+            class="required" />
         </validation-provider>
         <validation-provider
           v-slot="{ errors }"
@@ -43,7 +44,8 @@
             :error-messages="errors"
             label="Role"
             placeholder="Role..."
-            outlined />
+            outlined
+            class="required" />
         </validation-provider>
         <div class="d-flex justify-end">
           <v-btn @click="close" :disabled="isSaving" text>Cancel</v-btn>

--- a/client/components/repository/common/Sidebar/Relationship.vue
+++ b/client/components/repository/common/Sidebar/Relationship.vue
@@ -17,6 +17,7 @@
       :clearable="!multiple"
       :disabled="!options.length"
       :error-messages="errors"
+      :class="{ required: !allowEmpty }"
       item-text="data.name"
       deletable-chips return-object outlined />
   </validation-provider>

--- a/client/components/system-settings/UserManagement/UserDialog.vue
+++ b/client/components/system-settings/UserManagement/UserDialog.vue
@@ -29,7 +29,7 @@
             label="E-mail"
             placeholder="Enter email..."
             outlined
-            class="mb-3" />
+            class="required mb-3" />
         </validation-provider>
         <validation-provider
           v-slot="{ errors }"
@@ -41,7 +41,7 @@
             label="First name"
             placeholder="Enter first name..."
             outlined
-            class="mb-3" />
+            class="required mb-3" />
         </validation-provider>
         <validation-provider
           v-slot="{ errors }"
@@ -53,7 +53,7 @@
             label="Last name"
             placeholder="Enter last name..."
             outlined
-            class="mb-3" />
+            class="required mb-3" />
         </validation-provider>
         <validation-provider v-slot="{ errors }" name="role" rules="required">
           <v-select
@@ -63,7 +63,7 @@
             label="Role"
             placeholder="Select role..."
             outlined
-            class="mb-3" />
+            class="required mb-3" />
         </validation-provider>
         <div class="d-flex justify-end">
           <v-btn @click="close" text>Cancel</v-btn>

--- a/client/components/user-settings/ChangePasswordDialog.vue
+++ b/client/components/user-settings/ChangePasswordDialog.vue
@@ -28,7 +28,7 @@
             label="Current password"
             placeholder="Enter current password..."
             outlined
-            class="my-4" />
+            class="required my-4" />
         </validation-provider>
         <validation-provider
           v-slot="{ errors }"
@@ -42,7 +42,7 @@
             label="New password"
             placeholder="Enter new password..."
             outlined
-            class="mb-4" />
+            class="required mb-4" />
         </validation-provider>
         <validation-provider
           v-slot="{ errors }"
@@ -56,7 +56,7 @@
             label="Confirm new password"
             placeholder="Confirm new password..."
             outlined
-            class="mb-4" />
+            class="required mb-4" />
         </validation-provider>
         <div class="d-flex align-center pl-2 py-4">
           <router-link :to="{ name: 'forgot-password' }">

--- a/client/components/user-settings/Info.vue
+++ b/client/components/user-settings/Info.vue
@@ -15,7 +15,8 @@
         :error-messages="errors"
         name="email"
         label="Email"
-        outlined />
+        outlined
+        class="required" />
     </validation-provider>
     <validation-provider
       v-slot="{ errors }"
@@ -26,7 +27,8 @@
         :error-messages="errors"
         name="firstName"
         label="First name"
-        outlined />
+        outlined
+        class="required" />
     </validation-provider>
     <validation-provider
       v-slot="{ errors }"
@@ -37,7 +39,8 @@
         :error-messages="errors"
         name="lastName"
         label="Last name"
-        outlined />
+        outlined
+        class="required" />
     </validation-provider>
     <div class="d-flex justify-end">
       <v-btn @click="resetForm" :disabled="!hasChanges" text>


### PR DESCRIPTION
This PR:
- adds `required` class to all inputs with required rule set
- adds `slim` attribute to `validation-provider` in `meta-input` and `meta-textarea` components thus allowing `required` class to be set properly by `MetaInput` component

Issue: https://github.com/ExtensionEngine/tailor/issues/595