### PR TITLE
Implement input asset empty save and cancel button feature

### DIFF
--- a/client/components/common/InputAsset.vue
+++ b/client/components/common/InputAsset.vue
@@ -55,14 +55,24 @@
       class="action">
       Edit
     </v-btn>
-    <v-btn
-      v-else
-      @click.stop="save"
-      :disabled="uploading || !hasAsset"
-      text
-      class="action">
-      {{ hasChanges ? 'Save' : 'Cancel' }}
-    </v-btn>
+    <template v-else>
+      <v-btn
+        v-if="hasChanges"
+        @click.stop="save"
+        :disabled="uploading"
+        text
+        class="action">
+        Save
+      </v-btn>
+      <v-btn
+        v-if="hasChanges || url"
+        @click.stop="cancel"
+        :disabled="uploading"
+        text
+        class="action">
+        Cancel
+      </v-btn>
+    </template>
   </v-toolbar-items>
 </template>
 
@@ -101,7 +111,7 @@ export default {
   computed: {
     hasAsset: vm => vm.file || vm.urlInput,
     isLinked: vm => !!vm.urlInput,
-    hasChanges: vm => vm.url !== (vm.isLinked ? vm.urlInput : get(vm, 'file.url')),
+    hasChanges: vm => vm.url !== (vm.isLinked ? vm.urlInput : get(vm, 'file.url', null)),
     fileName() {
       if (!this.file) return null;
       return last(this.file.url.split('___'));
@@ -116,6 +126,12 @@ export default {
       this.isEditing = false;
       const payload = this.file || { url: this.urlInput, publicUrl: this.urlInput };
       this.$emit('input', payload);
+    },
+    cancel() {
+      const isLinked = !isUploaded(this.url);
+      this.urlInput = isLinked ? this.url : null;
+      this.file = isLinked ? null : pick(this, ['url', 'publicUrl']);
+      this.isEditing = !this.url;
     }
   },
   components: { UploadBtn }

--- a/client/components/content-elements/tce-pdf/edit/Toolbar.vue
+++ b/client/components/content-elements/tce-pdf/edit/Toolbar.vue
@@ -31,9 +31,13 @@ export default {
     url: vm => get(vm.element, 'data.assets.url')
   },
   methods: {
-    save({ url, publicUrl }) {
+    save({ url }) {
       const element = cloneDeep(this.element);
-      set(element.data, 'assets.url', url);
+      if (url) set(element.data, 'assets.url', url);
+      else {
+        set(element.data, 'assets', null);
+        set(element.data, 'url', null);
+      }
       this.$elementBus.emit('save', element);
     }
   },

--- a/client/components/content-elements/tce-pdf/edit/Toolbar.vue
+++ b/client/components/content-elements/tce-pdf/edit/Toolbar.vue
@@ -33,11 +33,7 @@ export default {
   methods: {
     save({ url }) {
       const element = cloneDeep(this.element);
-      if (url) set(element.data, 'assets.url', url);
-      else {
-        set(element.data, 'assets', null);
-        set(element.data, 'url', null);
-      }
+      set(element.data, 'assets.url', url);
       this.$elementBus.emit('save', element);
     }
   },

--- a/client/components/content-elements/tce-video/edit/Toolbar.vue
+++ b/client/components/content-elements/tce-video/edit/Toolbar.vue
@@ -31,9 +31,13 @@ export default {
     url: vm => get(vm.element, 'data.assets.url')
   },
   methods: {
-    save({ url, publicUrl }) {
+    save({ url }) {
       const element = cloneDeep(this.element);
-      set(element.data, 'assets.url', url);
+      if (url) set(element.data, 'assets.url', url);
+      else {
+        set(element.data, 'assets', null);
+        set(element.data, 'url', null);
+      }
       this.$elementBus.emit('save', element);
     }
   },

--- a/client/components/content-elements/tce-video/edit/Toolbar.vue
+++ b/client/components/content-elements/tce-video/edit/Toolbar.vue
@@ -33,11 +33,7 @@ export default {
   methods: {
     save({ url }) {
       const element = cloneDeep(this.element);
-      if (url) set(element.data, 'assets.url', url);
-      else {
-        set(element.data, 'assets', null);
-        set(element.data, 'url', null);
-      }
+      set(element.data, 'assets.url', url);
       this.$elementBus.emit('save', element);
     }
   },

--- a/client/components/editor/ContentElement.vue
+++ b/client/components/editor/ContentElement.vue
@@ -23,7 +23,6 @@ import cloneDeep from 'lodash/cloneDeep';
 import { ContainedContent } from 'tce-core';
 import loader from '@/components/common/loader';
 import { mapChannels } from '@/plugins/radio';
-import set from 'lodash/set';
 import throttle from 'lodash/throttle';
 
 export default {
@@ -48,7 +47,7 @@ export default {
     },
     save: loader(async function (data) {
       const element = cloneDeep(this.element);
-      set(element, 'data', data);
+      Object.assign(element.data, data);
       if (element.embedded) return this.$emit('save', element);
       await this.saveElement(element);
       this.showNotification();

--- a/client/components/editor/ContentElement.vue
+++ b/client/components/editor/ContentElement.vue
@@ -23,6 +23,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import { ContainedContent } from 'tce-core';
 import loader from '@/components/common/loader';
 import { mapChannels } from '@/plugins/radio';
+import set from 'lodash/set';
 import throttle from 'lodash/throttle';
 
 export default {
@@ -47,7 +48,7 @@ export default {
     },
     save: loader(async function (data) {
       const element = cloneDeep(this.element);
-      Object.assign(element.data, data);
+      set(element, 'data', data);
       if (element.embedded) return this.$emit('save', element);
       await this.saveElement(element);
       this.showNotification();

--- a/server/shared/storage/helpers.js
+++ b/server/shared/storage/helpers.js
@@ -97,6 +97,7 @@ function defaultStaticsResolver(item) {
 async function resolveAssetsMap(element) {
   if (!get(element, 'data.assets')) return element;
   await Promise.map(toPairs(element.data.assets), async ([key, url]) => {
+    if (!url) return set(element.data, key, url);
     const isStorageResource = url.startsWith(STORAGE_PROTOCOL);
     const resolvedUrl = isStorageResource
       ? (await storage.getFileUrl(url.substr(STORAGE_PROTOCOL.length, url.length)))


### PR DESCRIPTION
This PR:
- enables empty asset in `tce-pdf` and `tce-video` to be saved
- adds cancel button functionality which acts as undo when asset is deleted in editing mode