### PR TITLE
Update tailor config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Defines the structure of the activity relationship field.
   prerequisite. False by default.
 - **allowInsideLineage** `Boolean` - Defines if an ancestor or a descendant can
   be a member of the relationship. False by default.
-- **allowedTypes** `Array<String>` - Defines activity types that can be associated.
+- **allowedTypes** `Array<String>` - Defines activity types that can be associated in a relationship.
 
 #### Metadata
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Defines the structure of the activity relationship field.
   prerequisite. False by default.
 - **allowInsideLineage** `Boolean` - Defines if an ancestor or a descendant can
   be a member of the relationship. False by default.
+- **allowedTypes** `Array<String>` - Defines activity types that can be associated.
 
 #### Metadata
 

--- a/tailor.config.js.example
+++ b/tailor.config.js.example
@@ -7,7 +7,7 @@ exports.SCHEMAS = [{
     type: 'GOAL',
     label: 'Goal',
     color: '#ff6590',
-    level: 1,
+    rootLevel: true,
     meta: [{
       key: 'description',
       type: 'INPUT',


### PR DESCRIPTION
- replaces `level` with `rootLevel` option
- adds missing `allowedTypes` option to readme