### PR TITLE
Update content element deletedAt field manually on patch

### DIFF
--- a/server/content-element/content-element.controller.js
+++ b/server/content-element/content-element.controller.js
@@ -38,7 +38,10 @@ function patch({ repository, user, body, params: { elementId } }, res) {
   const context = { userId: user.id, repository };
   return ContentElement.findByPk(elementId, { paranoid })
     .then(asset => asset || createError(NOT_FOUND, 'Element not found'))
-    .then(asset => asset.update(data, { context }))
+    .then(asset => {
+      asset.setDataValue('deletedAt', data.deletedAt);
+      return asset.update(data, { context });
+    })
     .then(asset => res.json({ data: asset }));
 }
 

--- a/server/content-element/content-element.controller.js
+++ b/server/content-element/content-element.controller.js
@@ -39,7 +39,7 @@ function patch({ repository, user, body, params: { elementId } }, res) {
   return ContentElement.findByPk(elementId, { paranoid })
     .then(asset => asset || createError(NOT_FOUND, 'Element not found'))
     .then(asset => {
-      asset.setDataValue('deletedAt', data.deletedAt);
+      if (asset.deletedAt) asset.setDataValue('deletedAt', null);
       return asset.update(data, { context });
     })
     .then(asset => res.json({ data: asset }));


### PR DESCRIPTION
This PR:
- manually sets `deletedAt` field in patch controller via `setDataValue` since `deletedAt` is not updated correctly with only passing updated properties using `update` method
- solves issue https://github.com/ExtensionEngine/tailor/issues/640