### PR TITLE
Restored the deprecated tes prop for containers

### DIFF
--- a/client/components/editor/structure/ContentContainers/index.vue
+++ b/client/components/editor/structure/ContentContainers/index.vue
@@ -26,6 +26,7 @@
       :position="index"
       :activities="activities"
       :elements="elements"
+      :tes="elements"
       v-bind="$attrs" />
     <div v-if="addBtnEnabled">
       <v-btn @click="addContainer" color="blue-grey darken-3" text class="mt-4">

--- a/client/content-plugins/ContainerRegistry.js
+++ b/client/content-plugins/ContainerRegistry.js
@@ -1,14 +1,26 @@
 import ComponentRegistry from './ComponentRegistry';
 import containerList from 'shared/core-containers';
+import get from 'lodash/get';
 import { getContainerTemplateId as getId } from 'shared/activities';
 import { getContainerName as getName } from 'tce-core/utils';
+import { service as ValidationService } from './validation';
 
-const validator = ({ templateId, type }) => {
-  if (templateId) return;
-  console.warn(`
-    For container ${type} using depricated type identification!
-    Use templateId instead!
-  `);
+const getTemplateMessage = name => `
+  For container ${name} using depricated 'type' identification!
+  Use 'templateId' instead!
+`;
+
+const getElementsMessage = name => `
+  For container ${name} using depricated 'tes' prop!
+  Use 'elements' instead!
+`;
+
+const validator = ({ Edit: template, templateId, type }) => {
+  const name = templateId || type;
+
+  ValidationService
+    .validate(!templateId, getTemplateMessage(name))
+    .validate(get(template, 'props.tes'), getElementsMessage(name));
 };
 
 export default Vue => new ComponentRegistry(Vue, {

--- a/client/content-plugins/validation/ValidationService.js
+++ b/client/content-plugins/validation/ValidationService.js
@@ -1,0 +1,10 @@
+import types from './types';
+
+class ValidationService {
+  validate(condition, message, type = types.WARNING) {
+    if (condition) console[type](message);
+    return this;
+  }
+}
+
+export default new ValidationService();

--- a/client/content-plugins/validation/index.js
+++ b/client/content-plugins/validation/index.js
@@ -1,0 +1,7 @@
+import service from './ValidationService';
+import types from './types';
+
+export {
+  service,
+  types
+};

--- a/client/content-plugins/validation/types.js
+++ b/client/content-plugins/validation/types.js
@@ -1,0 +1,4 @@
+export default {
+  ERROR: 'error',
+  WARNING: 'warn'
+};


### PR DESCRIPTION
This PR restores the deprecated `tes` prop for containers so that existing custom content containers continue to function without needing to rename it the prop to `elements`. Because the prop is deprecated, a deprecation message is shown if a container is found using the prop.

Also, a small validation service was added that encapsulates the validation messaging logic.