### PR TITLE
Fix assessment items expanding/collapsing

### DIFF
--- a/client/components/content-containers/tcc-assessment-pool/edit/index.vue
+++ b/client/components/content-containers/tcc-assessment-pool/edit/index.vue
@@ -76,21 +76,21 @@ export default {
       if (this.isSelected(assessment) && !hasQuestion) {
         this.$emit('deleteElement', assessment);
       } else if (this.isSelected(assessment)) {
-        this.selected.splice(this.selected.indexOf(assessment._cid), 1);
+        this.selected.splice(this.selected.indexOf(assessment.uid), 1);
       } else {
-        this.selected.push(assessment._cid);
+        this.selected.push(assessment.uid);
       }
     },
     isSelected(assessment) {
-      return this.selected.includes(assessment._cid);
+      return this.selected.includes(assessment.uid);
     },
     clearSelected() {
-      const ids = this.assessments.map(it => it._cid);
+      const ids = this.assessments.map(it => it.uid);
       this.selected = this.selected.filter(it => ids.includes(it));
     },
     toggleAssessments() {
       this.allSelected = !this.allSelected;
-      this.selected = this.allSelected ? this.assessments.map(it => it._cid) : [];
+      this.selected = this.allSelected ? this.assessments.map(it => it.uid) : [];
     }
   },
   watch: {


### PR DESCRIPTION
This PR resolves issue with expanding and collapsing single assessment item within assessment pool. Prior this fix all assessments have been expanded/collapsed when trying to switch single of them.
![recording](https://user-images.githubusercontent.com/21145871/97184510-48969880-179f-11eb-96b0-cc6d62b7cf28.gif)
