### PR TITLE
Improve image loading in `tce-image`

### DIFF
--- a/client/components/content-elements/tce-image/edit/index.vue
+++ b/client/components/content-elements/tce-image/edit/index.vue
@@ -52,7 +52,6 @@
 <script>
 import Cropper from './Cropper';
 import { ElementPlaceholder } from 'tce-core';
-import get from 'lodash/get';
 import { imgSrcToDataURL } from 'blob-util';
 import isEmpty from 'lodash/isEmpty';
 
@@ -96,12 +95,12 @@ export default {
       if (this.$refs.cropper) this.$refs.cropper.destroy();
       return true;
     },
-    elementWidth: ({ containerWidth, element }) => get(element, 'data.meta.width'),
-    elementHeight: ({ containerWidth, element }) => get(element, 'data.meta.height'),
+    elementWidth: ({ containerWidth, element }) => element.data.meta?.width,
+    elementHeight: ({ containerWidth, element }) => element.data.meta?.height,
     maxWidth: ({ containerWidth, elementWidth }) =>
       containerWidth > elementWidth ? elementWidth : containerWidth,
     aspectRatio: ({ elementHeight, elementWidth }) =>
-      elementHeight && elementWidth && elementWidth / elementHeight
+      elementHeight && elementWidth && (elementWidth / elementHeight)
   },
   methods: {
     onReady() {

--- a/client/components/content-elements/tce-image/edit/index.vue
+++ b/client/components/content-elements/tce-image/edit/index.vue
@@ -27,7 +27,24 @@
         :modal="false"
         :src="currentImage"
         drag-mode="none" />
-      <img v-show="!showCropper" :src="currentImage" class="preview-image">
+      <v-img
+        v-show="!showCropper"
+        :aspect-ratio="aspectRatio"
+        :max-width="maxWidth"
+        :src="currentImage"
+        class="mx-auto">
+        <template v-slot:placeholder>
+          <v-row
+            class="fill-height ma-0"
+            align="center"
+            justify="center">
+            <v-icon size="50" color="grey lighten-1" class="image-icon">
+              mdi-image-outline
+            </v-icon>
+            <v-progress-circular size="80" color="grey lighten-1" indeterminate />
+          </v-row>
+        </template>
+      </v-img>
     </div>
   </div>
 </template>
@@ -35,6 +52,7 @@
 <script>
 import Cropper from './Cropper';
 import { ElementPlaceholder } from 'tce-core';
+import get from 'lodash/get';
 import { imgSrcToDataURL } from 'blob-util';
 import isEmpty from 'lodash/isEmpty';
 
@@ -66,6 +84,7 @@ export default {
     dense: { type: Boolean, default: false }
   },
   data: () => ({
+    containerWidth: 0,
     currentImage: null,
     persistedImage: null,
     showCropper: false
@@ -76,7 +95,13 @@ export default {
       if (imageAvailable) return false;
       if (this.$refs.cropper) this.$refs.cropper.destroy();
       return true;
-    }
+    },
+    elementWidth: ({ containerWidth, element }) => get(element, 'data.meta.width'),
+    elementHeight: ({ containerWidth, element }) => get(element, 'data.meta.height'),
+    maxWidth: ({ containerWidth, elementWidth }) =>
+      containerWidth > elementWidth ? elementWidth : containerWidth,
+    aspectRatio: ({ elementHeight, elementWidth }) =>
+      elementHeight && elementWidth && elementWidth / elementHeight
   },
   methods: {
     onReady() {
@@ -105,6 +130,8 @@ export default {
     }
   },
   mounted() {
+    this.containerWidth = this.$el.parentElement.offsetWidth;
+
     toDataUrl(this.element.data.url)
       .then(dataUrl => this.load(dataUrl));
 
@@ -147,7 +174,7 @@ export default {
   display: none;
 }
 
-img {
-  max-width: 100%;
+.image-icon {
+  position: absolute;
 }
 </style>

--- a/client/components/content-elements/tce-image/edit/index.vue
+++ b/client/components/content-elements/tce-image/edit/index.vue
@@ -29,15 +29,15 @@
         drag-mode="none" />
       <v-img
         v-show="!showCropper"
+        :src="currentImage"
         :aspect-ratio="aspectRatio"
         :max-width="maxWidth"
-        :src="currentImage"
         class="mx-auto">
         <template v-slot:placeholder>
           <v-row
-            class="fill-height ma-0"
             align="center"
-            justify="center">
+            justify="center"
+            class="fill-height ma-0">
             <v-icon size="50" color="grey lighten-1" class="image-icon">
               mdi-image-outline
             </v-icon>


### PR DESCRIPTION
This PR:
- uses `v-img` component instead of `img` in `tce-image`
- adds loader and sets height of the container before the image is loaded
- resolves https://github.com/ExtensionEngine/tailor/issues/660

![Screen Shot 2020-11-10 at 11 48 50 AM](https://user-images.githubusercontent.com/7149531/98665240-b3bd9e80-234b-11eb-8fcf-9ff5d79d119a.png)
