### PR TITLE
Improve search input icon hover contrast

### DIFF
--- a/client/components/catalog/Card/Tags/index.vue
+++ b/client/components/catalog/Card/Tags/index.vue
@@ -21,8 +21,8 @@
     </div>
     <v-tooltip v-if="!exceededTagLimit" open-delay="400" bottom>
       <template v-slot:activator="{ on }">
-        <v-btn v-on="on" @click="showTagDialog = true" icon>
-          <v-icon color="blue-grey lighten-3" dense>mdi-tag-plus</v-icon>
+        <v-btn v-on="on" @click="showTagDialog = true" color="blue-grey lighten-3" icon>
+          <v-icon dense>mdi-tag-plus</v-icon>
         </v-btn>
       </template>
       Add tag

--- a/client/components/catalog/Card/index.vue
+++ b/client/components/catalog/Card/index.vue
@@ -25,7 +25,7 @@
               <v-btn
                 v-on="on"
                 @click.stop="navigateTo('repository-info')"
-                color="blue-grey darken-2"
+                color="blue-grey darken-1"
                 icon
                 class="repo-info mr-2">
                 <v-icon>mdi-settings</v-icon>

--- a/client/components/catalog/Card/index.vue
+++ b/client/components/catalog/Card/index.vue
@@ -25,7 +25,7 @@
               <v-btn
                 v-on="on"
                 @click.stop="navigateTo('repository-info')"
-                color="blue-grey darken-1"
+                color="blue-grey lighten-2"
                 icon
                 class="mr-2">
                 <v-icon>mdi-settings</v-icon>

--- a/client/components/catalog/Card/index.vue
+++ b/client/components/catalog/Card/index.vue
@@ -25,9 +25,9 @@
               <v-btn
                 v-on="on"
                 @click.stop="navigateTo('repository-info')"
-                color="blue-grey lighten-2"
+                color="blue-grey darken-2"
                 icon
-                class="mr-2">
+                class="repo-info mr-2">
                 <v-icon>mdi-settings</v-icon>
               </v-btn>
             </template>
@@ -59,13 +59,10 @@
             <v-btn
               v-on="on"
               @click.stop="pin({ id: repository.id, pin: !isPinned })"
+              :color="isPinned ? 'lime accent-4': 'blue-grey lighten-3'"
               icon
               class="mr-1">
-              <v-icon
-                :color="isPinned ? 'lime accent-4': 'blue-grey lighten-2'"
-                :class="{ 'mdi-rotate-45': isPinned }">
-                mdi-pin
-              </v-icon>
+              <v-icon :class="{ 'mdi-rotate-45': isPinned }">mdi-pin</v-icon>
             </v-btn>
           </template>
           {{ isPinned ? 'Unpin' : 'Pin' }} {{ schema }}
@@ -155,5 +152,9 @@ export default {
   .v-avatar {
     margin-top: 0.125rem;
   }
+}
+
+.repo-info.v-btn:not(.v-btn--text):not(.v-btn--outlined):hover::before {
+  opacity: 0.2;
 }
 </style>

--- a/client/components/catalog/Container.vue
+++ b/client/components/catalog/Container.vue
@@ -14,11 +14,10 @@
               <v-btn
                 v-on="on"
                 @click="onFilterChange(togglePinned)"
+                :color="showPinned ? 'lime accent-3' : 'primary lighten-4'"
                 icon
                 class="my-1">
-                <v-icon :color="showPinned ? 'lime accent-3' : 'primary lighten-4'">
-                  mdi-pin
-                </v-icon>
+                <v-icon>mdi-pin</v-icon>
               </v-btn>
             </template>
             <span>{{ showPinned ? 'Show all' : 'Show pinned' }}</span>
@@ -192,9 +191,5 @@ export default {
     top: 10px;
     right: 12px;
   }
-}
-
-.v-btn:not(.v-btn--text):not(.v-btn--outlined):hover::before {
-  opacity: 0.2;
 }
 </style>

--- a/client/components/catalog/Container.vue
+++ b/client/components/catalog/Container.vue
@@ -14,7 +14,7 @@
               <v-btn
                 v-on="on"
                 @click="onFilterChange(togglePinned)"
-                icon text
+                icon
                 class="my-1">
                 <v-icon :color="showPinned ? 'lime accent-3' : 'primary lighten-4'">
                   mdi-pin
@@ -192,5 +192,9 @@ export default {
     top: 10px;
     right: 12px;
   }
+}
+
+.v-btn:not(.v-btn--text):not(.v-btn--outlined):hover::before {
+  opacity: 0.2;
 }
 </style>

--- a/client/components/catalog/SelectOrder.vue
+++ b/client/components/catalog/SelectOrder.vue
@@ -6,7 +6,7 @@
           <template v-slot:activator="{ on: tooltip }">
             <v-btn
               v-on="{ ...menu, ...tooltip }"
-              icon text
+              icon
               class="my-1">
               <v-icon color="primary lighten-4">mdi-sort</v-icon>
             </v-btn>
@@ -29,7 +29,7 @@
         <v-btn
           v-on="on"
           @click="toggleOrder"
-          icon text
+          icon
           class="my-1">
           <v-icon color="primary lighten-4">
             mdi-sort-{{ sortBy.order === 'ASC' ? 'ascending' : 'descending' }}
@@ -66,5 +66,9 @@ export default {
 <style lang="scss" scoped>
 .v-menu, .v-btn {
   display: inline-block;
+}
+
+.v-btn:not(.v-btn--text):not(.v-btn--outlined):hover::before {
+  opacity: 0.2;
 }
 </style>

--- a/client/components/catalog/SelectOrder.vue
+++ b/client/components/catalog/SelectOrder.vue
@@ -6,9 +6,10 @@
           <template v-slot:activator="{ on: tooltip }">
             <v-btn
               v-on="{ ...menu, ...tooltip }"
+              color="primary lighten-4"
               icon
               class="my-1">
-              <v-icon color="primary lighten-4">mdi-sort</v-icon>
+              <v-icon>mdi-sort</v-icon>
             </v-btn>
           </template>
           <span>Order by</span>
@@ -29,9 +30,10 @@
         <v-btn
           v-on="on"
           @click="toggleOrder"
+          color="primary lighten-4"
           icon
           class="my-1">
-          <v-icon color="primary lighten-4">
+          <v-icon>
             mdi-sort-{{ sortBy.order === 'ASC' ? 'ascending' : 'descending' }}
           </v-icon>
         </v-btn>
@@ -66,9 +68,5 @@ export default {
 <style lang="scss" scoped>
 .v-menu, .v-btn {
   display: inline-block;
-}
-
-.v-btn:not(.v-btn--text):not(.v-btn--outlined):hover::before {
-  opacity: 0.2;
 }
 </style>

--- a/client/components/catalog/TagFilter.vue
+++ b/client/components/catalog/TagFilter.vue
@@ -10,8 +10,8 @@
         open-delay="800"
         top>
         <template v-slot:activator="{ on: tooltip }">
-          <v-btn v-on="{ ...menu, ...tooltip }" icon>
-            <v-icon color="primary lighten-4">mdi-tag-outline</v-icon>
+          <v-btn v-on="{ ...menu, ...tooltip }" color="primary lighten-4" icon>
+            <v-icon>mdi-tag-outline</v-icon>
           </v-btn>
         </template>
         <span>Tags</span>
@@ -77,9 +77,5 @@ export default {
   max-height: 18.75rem;
   border-radius: 0;
   overflow-y: auto;
-}
-
-.v-btn:not(.v-btn--text):not(.v-btn--outlined):hover::before {
-  opacity: 0.2;
 }
 </style>

--- a/client/components/catalog/TagFilter.vue
+++ b/client/components/catalog/TagFilter.vue
@@ -10,7 +10,7 @@
         open-delay="800"
         top>
         <template v-slot:activator="{ on: tooltip }">
-          <v-btn v-on="{ ...menu, ...tooltip }" icon text>
+          <v-btn v-on="{ ...menu, ...tooltip }" icon>
             <v-icon color="primary lighten-4">mdi-tag-outline</v-icon>
           </v-btn>
         </template>
@@ -79,4 +79,7 @@ export default {
   overflow-y: auto;
 }
 
+.v-btn:not(.v-btn--text):not(.v-btn--outlined):hover::before {
+  opacity: 0.2;
+}
 </style>


### PR DESCRIPTION
This PR:
- updates icons hover background opacity to improve background contrast per points 1 and 2 of issue https://github.com/ExtensionEngine/tailor/issues/656

![Screen Shot 2020-11-12 at 6 37 52 PM](https://user-images.githubusercontent.com/7149531/98975266-2ed2b080-2516-11eb-8f7d-6e9f0c7746f4.png)
