### PR TITLE
Use 12-hour time format with AM/PM instead of 24-hours

### DIFF
--- a/client/components/repository/Revisions/EntitySidebar.vue
+++ b/client/components/repository/Revisions/EntitySidebar.vue
@@ -44,7 +44,7 @@ export default {
       return revision.id === this.selected.id;
     },
     formatDate(rev) {
-      return fecha.format(new Date(rev.createdAt), 'M/D/YY HH:mm');
+      return fecha.format(new Date(rev.createdAt), 'M/D/YY h:mm A');
     },
     scrollTop() {
       this.$refs.revisions.scrollTop = 0;

--- a/client/components/repository/Revisions/RevisionItem.vue
+++ b/client/components/repository/Revisions/RevisionItem.vue
@@ -54,7 +54,7 @@ export default {
       return getRevisionAcronym(this.revision);
     },
     date() {
-      return fecha.format(this.revision.createdAt, 'M/D/YY HH:mm');
+      return fecha.format(this.revision.createdAt, 'M/D/YY h:mm A');
     },
     description() {
       return getFormatDescription(this.revision, this.activity);

--- a/client/components/repository/common/Sidebar/Publishing.vue
+++ b/client/components/repository/common/Sidebar/Publishing.vue
@@ -50,7 +50,7 @@ export default {
     publishedAtMessage() {
       const { publishedAt } = this.activity;
       return publishedAt
-        ? `Published on ${fecha.format(new Date(publishedAt), 'M/D/YY HH:mm')}`
+        ? `Published on ${fecha.format(new Date(publishedAt), 'M/D/YY h:mm A')}`
         : 'Not published';
     },
     activityWithDescendants({ outlineActivities, activity } = this) {


### PR DESCRIPTION
This PR:
- updates 24-hours date time format to 12-hour format with AM/PM on all places where 24-hours format was used, per point 7 of issue https://github.com/ExtensionEngine/tailor/issues/656