### PR TITLE
Improve element drag and drop feature

### DIFF
--- a/client/components/common/tce-core/ContentElement.vue
+++ b/client/components/common/tce-core/ContentElement.vue
@@ -130,6 +130,7 @@ export default {
   $accent-2: #ff4081;
 
   position: relative;
+  background: #fff;
 
   &::after {
     $width: 0.125rem;

--- a/client/components/common/tce-core/ContentElement.vue
+++ b/client/components/common/tce-core/ContentElement.vue
@@ -130,7 +130,6 @@ export default {
   $accent-2: #ff4081;
 
   position: relative;
-  background: #fff;
 
   &::after {
     $width: 0.125rem;

--- a/client/components/common/tce-core/ElementList.vue
+++ b/client/components/common/tce-core/ElementList.vue
@@ -119,6 +119,7 @@ export default {
 
 ::v-deep .sortable-drag .content-element {
   max-height: auto;
+  background: #fff;
 }
 
 </style>

--- a/client/components/common/tce-core/ElementList.vue
+++ b/client/components/common/tce-core/ElementList.vue
@@ -69,9 +69,7 @@ export default {
     ...mapChannels({ editorChannel: 'editor' }),
     options: vm => ({
       ...vm.dragOptions,
-      handle: '.drag-handle',
-      scrollSpeed: 15,
-      scrollSensitivity: 125
+      handle: '.drag-handle'
     }),
     nextPosition() {
       const lastItem = last(this.elements);

--- a/client/components/common/tce-core/ElementList.vue
+++ b/client/components/common/tce-core/ElementList.vue
@@ -104,15 +104,17 @@ export default {
   padding: 0.625rem 1.5rem;
 }
 
-::v-deep .sortable-ghost .content-element {
-  background: #f4f5f5;
-
-  & > * {
-    visibility: hidden;
+::v-deep .sortable-ghost {
+  .drag-handle {
+    display: none;
   }
-}
 
-::v-deep .sortable-chosen .drag-handle {
-  display: none;
+  .content-element {
+    background: #f4f5f5;
+
+    & > * {
+      visibility: hidden;
+    }
+  }
 }
 </style>

--- a/client/components/common/tce-core/ElementList.vue
+++ b/client/components/common/tce-core/ElementList.vue
@@ -103,4 +103,8 @@ export default {
 .list-group {
   padding: 0.625rem 1.5rem;
 }
+
+::v-deep .sortable-ghost .content-element {
+  background: #f4f5f5;
+}
 </style>

--- a/client/components/common/tce-core/ElementList.vue
+++ b/client/components/common/tce-core/ElementList.vue
@@ -106,5 +106,9 @@ export default {
 
 ::v-deep .sortable-ghost .content-element {
   background: #f4f5f5;
+
+  & > * {
+    visibility: hidden;
+  }
 }
 </style>

--- a/client/components/common/tce-core/ElementList.vue
+++ b/client/components/common/tce-core/ElementList.vue
@@ -110,7 +110,7 @@ export default {
   }
 
   .content-element {
-    max-height: 150px;
+    max-height: 9.375rem;
     background: #f4f5f5;
 
     & > * {

--- a/client/components/common/tce-core/ElementList.vue
+++ b/client/components/common/tce-core/ElementList.vue
@@ -111,4 +111,8 @@ export default {
     visibility: hidden;
   }
 }
+
+::v-deep .sortable-chosen .drag-handle {
+  display: none;
+}
 </style>

--- a/client/components/common/tce-core/ElementList.vue
+++ b/client/components/common/tce-core/ElementList.vue
@@ -110,6 +110,7 @@ export default {
   }
 
   .content-element {
+    max-height: 150px;
     background: #f4f5f5;
 
     & > * {
@@ -117,4 +118,9 @@ export default {
     }
   }
 }
+
+::v-deep .sortable-drag .content-element {
+  max-height: auto;
+}
+
 </style>

--- a/package-lock.json
+++ b/package-lock.json
@@ -18642,11 +18642,6 @@
         "is-plain-obj": "^2.0.0"
       }
     },
-    "sortablejs": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.12.0.tgz",
-      "integrity": "sha512-bPn57rCjBRlt2sC24RBsu40wZsmLkSo2XeqG8k6DC1zru5eObQUIPPZAQG7W2SJ8FZQYq+BEJmvuw1Zxb3chqg=="
-    },
     "source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -21221,11 +21216,18 @@
       }
     },
     "vuedraggable": {
-      "version": "2.24.1",
-      "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-2.24.1.tgz",
-      "integrity": "sha512-G1fxO1oshx+WLdieSGl6jSJdlHOQFga1FpjuUpgXldbpKNzxpjsGn4xYNnRHVrOAqm8aG5FfpdQlh5LHesxCeA==",
+      "version": "2.24.3",
+      "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-2.24.3.tgz",
+      "integrity": "sha512-6/HDXi92GzB+Hcs9fC6PAAozK1RLt1ewPTLjK0anTYguXLAeySDmcnqE8IC0xa7shvSzRjQXq3/+dsZ7ETGF3g==",
       "requires": {
-        "sortablejs": "^1.10.1"
+        "sortablejs": "1.10.2"
+      },
+      "dependencies": {
+        "sortablejs": {
+          "version": "1.10.2",
+          "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.10.2.tgz",
+          "integrity": "sha512-YkPGufevysvfwn5rfdlGyrGjt7/CRHwvRPogD/lC+TnvcN29jDpCifKP+rBqf+LRldfXSTh+0CGLcSg0VIxq3A=="
+        }
       }
     },
     "vuetify": {

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "vue-quill-editor": "^2.3.3",
     "vue-router": "^3.1.5",
     "vue-timeago": "^5.1.2",
-    "vuedraggable": "^2.23.2",
+    "vuedraggable": "^2.24.3",
     "vuetify": "^2.2.20",
     "vuex": "^3.1.1",
     "vuex-persist": "^2.2.0",


### PR DESCRIPTION
This PR:
- adds light gray `#f4f5f5` background to dragged element drop area and hides the content inside
- sets `max-height` to `9.375rem` (150px) on dragged element drop area