### PR TITLE
Avoid compiling server files inside the custom content element

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = {
   },
   overrides: [{
     files: ['extensions/**'],
+    excludedFiles: ['extensions/**/util.js'],
     parserOptions: {
       parser: '@babel/eslint-parser',
       sourceType: 'module'

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,7 @@ module.exports = {
   },
   overrides: [{
     files: ['extensions/**'],
-    excludedFiles: ['extensions/**/server/**/*'],
+    excludedFiles: ['extensions/**/server/**'],
     parserOptions: {
       parser: '@babel/eslint-parser',
       sourceType: 'module'

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,14 +12,22 @@ module.exports = {
     'vuetify/grid-unknown-attributes': 'error',
     'vuetify/no-legacy-grid': 'error'
   },
-  overrides: [{
-    files: ['extensions/**'],
-    excludedFiles: ['extensions/**/server/**'],
-    parserOptions: {
-      parser: '@babel/eslint-parser',
-      sourceType: 'module'
+  overrides: [
+    {
+      files: ['client/components/content-elements/**/server/**'],
+      parserOptions: {
+        sourceType: 'script'
+      }
+    },
+    {
+      files: ['extensions/**'],
+      excludedFiles: ['extensions/content-elements/**/server/**'],
+      parserOptions: {
+        parser: '@babel/eslint-parser',
+        sourceType: 'module'
+      }
     }
-  }],
+  ],
   globals: {
     BRAND_CONFIG: true
   }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,7 @@ module.exports = {
   },
   overrides: [{
     files: ['extensions/**'],
-    excludedFiles: ['extensions/**/util.js'],
+    excludedFiles: ['extensions/**/hooks/**/*'],
     parserOptions: {
       parser: '@babel/eslint-parser',
       sourceType: 'module'

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,7 @@ module.exports = {
   },
   overrides: [{
     files: ['extensions/**'],
-    excludedFiles: ['extensions/**/hooks/**/*'],
+    excludedFiles: ['extensions/**/server/**/*'],
     parserOptions: {
       parser: '@babel/eslint-parser',
       sourceType: 'module'

--- a/client/components/content-elements/tce-image/server/index.js
+++ b/client/components/content-elements/tce-image/server/index.js
@@ -1,5 +1,7 @@
+'use strict';
+
 const crypto = require('crypto');
-const info = require('./info');
+const info = require('../info');
 const isString = require('lodash/isString');
 const isUrl = require('is-url');
 const mime = require('mime-types');

--- a/client/components/content-elements/tce-scorm/server/index.js
+++ b/client/components/content-elements/tce-scorm/server/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const { beforeSave } = require('@extensionengine/tce-scorm/dist/util');
 const { options } = require('@extensionengine/tce-scorm/dist/tce-scorm');
 

--- a/client/content-plugins/ComponentRegistry.js
+++ b/client/content-plugins/ComponentRegistry.js
@@ -52,7 +52,7 @@ export default class ComponentRegistry {
     const { position = _registry.length, isExtension } = options;
     const element = isExtension
       ? (await import(
-        /* webpackExclude: /util\.js$/ */
+        /* webpackExclude: /hooks\/.*$/ */
         `extensions/${_type}s/${path}`
       )).default
       : (await import(`components/${_type}s/${path}`)).default;
@@ -78,7 +78,7 @@ export default class ComponentRegistry {
 
   loadExtensionList() {
     return import(
-      /* webpackExclude: /util\.js$/ */
+      /* webpackExclude: /hooks\/.*$/ */
       `extensions/${this._type}s/${EXTENSIONS_LIST}`
     )
       .then(module => module.default)

--- a/client/content-plugins/ComponentRegistry.js
+++ b/client/content-plugins/ComponentRegistry.js
@@ -51,7 +51,10 @@ export default class ComponentRegistry {
     const { _registry, _type, _attrs, Vue } = this;
     const { position = _registry.length, isExtension } = options;
     const element = isExtension
-      ? (await import(`extensions/${_type}s/${path}`)).default
+      ? (await import(
+        /* webpackExclude: /util\.js$/ */
+        `extensions/${_type}s/${path}`
+      )).default
       : (await import(`components/${_type}s/${path}`)).default;
     this._validator(element);
 
@@ -74,7 +77,10 @@ export default class ComponentRegistry {
   }
 
   loadExtensionList() {
-    return import(`extensions/${this._type}s/${EXTENSIONS_LIST}`)
+    return import(
+      /* webpackExclude: /util\.js$/ */
+      `extensions/${this._type}s/${EXTENSIONS_LIST}`
+    )
       .then(module => module.default)
       .catch(() => console.log(`No ${this._name} extensions loaded!`) || []);
   }

--- a/client/content-plugins/ComponentRegistry.js
+++ b/client/content-plugins/ComponentRegistry.js
@@ -55,7 +55,10 @@ export default class ComponentRegistry {
         /* webpackExclude: /server\/.*$/ */
         `extensions/${_type}s/${path}`
       )).default
-      : (await import(`components/${_type}s/${path}`)).default;
+      : (await import(
+        /* webpackExclude: /server\/.*$/ */
+        `components/${_type}s/${path}`
+      )).default;
     this._validator(element);
 
     const id = getIdentifier(element);

--- a/client/content-plugins/ComponentRegistry.js
+++ b/client/content-plugins/ComponentRegistry.js
@@ -52,7 +52,7 @@ export default class ComponentRegistry {
     const { position = _registry.length, isExtension } = options;
     const element = isExtension
       ? (await import(
-        /* webpackExclude: /hooks\/.*$/ */
+        /* webpackExclude: /server\/.*$/ */
         `extensions/${_type}s/${path}`
       )).default
       : (await import(`components/${_type}s/${path}`)).default;
@@ -78,7 +78,7 @@ export default class ComponentRegistry {
 
   loadExtensionList() {
     return import(
-      /* webpackExclude: /hooks\/.*$/ */
+      /* webpackExclude: /server\/.*$/ */
       `extensions/${this._type}s/${EXTENSIONS_LIST}`
     )
       .then(module => module.default)

--- a/server/shared/content-plugins/BaseRegistry.js
+++ b/server/shared/content-plugins/BaseRegistry.js
@@ -31,7 +31,7 @@ module.exports = class {
 
   getFullPath(path, isExtension) {
     const basePath = isExtension ? PATHS.EXTENSION : PATHS.DEFAULT;
-    return `${basePath}/content-${this._type}s/${path}/util`;
+    return `${basePath}/content-${this._type}s/${path}/hooks`;
   }
 
   loadExtensionList() {

--- a/server/shared/content-plugins/BaseRegistry.js
+++ b/server/shared/content-plugins/BaseRegistry.js
@@ -31,7 +31,7 @@ module.exports = class {
 
   getFullPath(path, isExtension) {
     const basePath = isExtension ? PATHS.EXTENSION : PATHS.DEFAULT;
-    return `${basePath}/content-${this._type}s/${path}/hooks`;
+    return `${basePath}/content-${this._type}s/${path}/server`;
   }
 
   loadExtensionList() {


### PR DESCRIPTION
**This PR:**
- exclude server files inside the custom content element from webpack build
- edit eslint configuration
- import server hooks from the `extensions/custom-elements/element-name/server/index.js`

❗ **Breaking change**
- `tce/util.js` should be moved to `tce/server/index.js`
[Tce repo](https://github.com/ExtensionEngine/tailor-element-template) also needs to be updated.