### PR TITLE
Removed unused url-regex library with its security issues (ReDos)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10693,11 +10693,6 @@
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
-    "ip-regex": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.2.0.tgz",
-      "integrity": "sha512-n5cDDeTWWRwK1EBoWwRti+8nP4NbytBBY0pldmnIkq6Z55KNFmWofh4rl9dPZpj+U/nVq7gweR3ylrvMt4YZ5A=="
-    },
     "ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -20066,11 +20061,6 @@
       "resolved": "https://registry.npmjs.org/title-case-minors/-/title-case-minors-1.0.0.tgz",
       "integrity": "sha1-UfFwN8KUdHodHNpCS1AEyG2OsRU="
     },
-    "tlds": {
-      "version": "1.210.0",
-      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.210.0.tgz",
-      "integrity": "sha512-5bzt4JE+NlnwiKpVW9yzWxuc44m+t2opmPG+eSKDp5V5qdyGvjMngKgBb5ZK8GiheQMbRTCKpRwFJeIEO6pV7Q=="
-    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -20810,15 +20800,6 @@
       "version": "1.1.10",
       "resolved": "https://registry.npmjs.org/url-polyfill/-/url-polyfill-1.1.10.tgz",
       "integrity": "sha512-vSaPpaRgBrf41+Uky1myiSh6gpcbw8FpwHYnEy0abxndojOBnIs+yh/49gKYFLtUMP9qoNWjn6j9aUVy23Ie2A=="
-    },
-    "url-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/url-regex/-/url-regex-5.0.0.tgz",
-      "integrity": "sha512-O08GjTiAFNsSlrUWfqF1jH0H1W3m35ZyadHrGv5krdnmPPoxP27oDTqux/579PtaroiSGm5yma6KT1mHFH6Y/g==",
-      "requires": {
-        "ip-regex": "^4.1.0",
-        "tlds": "^1.203.0"
-      }
     },
     "use": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,6 @@
     "untildify": "^4.0.0",
     "url-join": "^4.0.1",
     "url-parse": "^1.4.7",
-    "url-regex": "^5.0.0",
     "v-hotkey": "^0.8.0",
     "validator": "^13.1.17",
     "vee-validate": "^3.3.0",


### PR DESCRIPTION
This PR removes the unused [url-regex](https://github.com/kevva/url-regex) library and it should also resolve the possible security issue reported by the Snyk [here](https://snyk.io/test/github/ExtensionEngine/tailor#SNYK-JS-URLREGEX-569472)