### PR TITLE
Truncate long schema names

### DIFF
--- a/client/components/catalog/Card/index.vue
+++ b/client/components/catalog/Card/index.vue
@@ -122,6 +122,11 @@ export default {
       this.isTruncated = clientWidth < scrollWidth;
     }
   },
+  watch: {
+    '$vuetify.breakpoint.width'() {
+      this.detectTruncation();
+    }
+  },
   mounted() {
     this.$nextTick(() => this.detectTruncation());
   },

--- a/client/components/catalog/Card/index.vue
+++ b/client/components/catalog/Card/index.vue
@@ -8,9 +8,9 @@
       <div @click="navigateTo()" class="card-body">
         <div class="header ml-4">
           <v-chip :color="repository.data.color" x-small class="readonly px-1" />
-          <v-tooltip open-delay="300" top>
+          <v-tooltip :disabled="!isTruncated" open-delay="300" top>
             <template v-slot:activator="{ on }">
-              <span v-on="on" class="schema-name mx-2">{{ schema }}</span>
+              <span ref="schemaName" v-on="on" class="schema-name mx-2">{{ schema }}</span>
             </template>
             {{ schema }}
           </v-tooltip>
@@ -93,6 +93,7 @@ export default {
   props: {
     repository: { type: Object, required: true }
   },
+  data: () => ({ isTruncated: false }),
   computed: {
     name: ({ repository }) => repository.name,
     description: ({ repository }) => repository.description,
@@ -110,7 +111,14 @@ export default {
         name,
         params: { repositoryId: this.repository.id }
       });
+    },
+    detectTruncation() {
+      const { clientWidth, scrollWidth } = this.$refs.schemaName;
+      this.isTruncated = clientWidth < scrollWidth;
     }
+  },
+  mounted() {
+    this.$nextTick(() => this.detectTruncation());
   },
   components: { Tags }
 };

--- a/client/components/catalog/Card/index.vue
+++ b/client/components/catalog/Card/index.vue
@@ -6,9 +6,9 @@
       dark
       class="repository-card">
       <div @click="navigateTo()" class="card-body">
-        <v-chip :color="repository.data.color" x-small class="readonly ml-4 px-1" />
-        <span class="schema-name">{{ schema }}</span>
-        <div class="controls float-right">
+        <div class="header ml-4">
+          <v-chip :color="repository.data.color" x-small class="readonly px-1" />
+          <span class="schema-name mx-2">{{ schema }}</span>
           <v-tooltip open-delay="100" top>
             <template v-slot:activator="{ on }">
               <span v-on="on">
@@ -133,22 +133,25 @@ export default {
 .card-body {
   padding: 0.625rem 0 0;
 
-  .v-card__title {
-    line-height: 1.75rem;
+  .header {
+    display: flex;
+    align-items: center;
   }
 
   .schema-name {
-    padding: 0 0 0 0.25rem;
+    flex-grow: 1;
     color: #fafafa;
     font-size: 0.75rem;
     font-weight: 500;
     letter-spacing: 1px;
     text-transform: uppercase;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
-  .controls {
-    display: flex;
-    align-items: center;
+  .v-card__title {
+    line-height: 1.75rem;
   }
 
   .v-avatar {

--- a/client/components/catalog/Card/index.vue
+++ b/client/components/catalog/Card/index.vue
@@ -8,7 +8,12 @@
       <div @click="navigateTo()" class="card-body">
         <div class="header ml-4">
           <v-chip :color="repository.data.color" x-small class="readonly px-1" />
-          <span class="schema-name mx-2">{{ schema }}</span>
+          <v-tooltip open-delay="300" top>
+            <template v-slot:activator="{ on }">
+              <span v-on="on" class="schema-name mx-2">{{ schema }}</span>
+            </template>
+            {{ schema }}
+          </v-tooltip>
           <v-tooltip open-delay="100" top>
             <template v-slot:activator="{ on }">
               <span v-on="on">

--- a/client/components/catalog/Card/index.vue
+++ b/client/components/catalog/Card/index.vue
@@ -4,13 +4,18 @@
       :elevation="isCardHovered ? 20 : 1"
       color="blue-grey darken-4"
       dark
-      class="repository-card">
+      class="repository-card d-flex flex-column justify-space-between text-left">
       <div @click="navigateTo()" class="card-body">
-        <div class="header ml-4">
+        <div class="d-flex align-center ml-4">
           <v-chip :color="repository.data.color" x-small class="readonly px-1" />
           <v-tooltip :disabled="!isTruncated" open-delay="300" top>
             <template v-slot:activator="{ on }">
-              <span ref="schemaName" v-on="on" class="schema-name mx-2">{{ schema }}</span>
+              <span
+                ref="schemaName"
+                v-on="on"
+                class="schema-name flex-grow-1 text-truncate text-uppercase mx-2">
+                {{ schema }}
+              </span>
             </template>
             {{ schema }}
           </v-tooltip>
@@ -126,11 +131,7 @@ export default {
 
 <style lang="scss" scoped>
 .repository-card {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
   height: 14.75rem;
-  text-align: left;
   transition: all 0.3s ease;
   cursor: pointer;
 
@@ -146,21 +147,11 @@ export default {
 .card-body {
   padding: 0.625rem 0 0;
 
-  .header {
-    display: flex;
-    align-items: center;
-  }
-
   .schema-name {
-    flex-grow: 1;
     color: #fafafa;
     font-size: 0.75rem;
     font-weight: 500;
     letter-spacing: 1px;
-    text-transform: uppercase;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
   }
 
   .v-card__title {


### PR DESCRIPTION
Yet another hacktoberfest PR 😂 

This PR truncates long schema name so they stack nicely with the cog and publishing info indicator.
Before:
![before](https://user-images.githubusercontent.com/21145871/105823983-1ecb5880-5fbe-11eb-8088-aa3218ce59a0.png)
After:
![after](https://user-images.githubusercontent.com/21145871/105824030-27bc2a00-5fbe-11eb-9c66-6dc4dd0fcd5f.png)

