### PR TITLE
Update tce-scorm server source path

### DIFF
--- a/client/components/content-elements/tce-scorm/server/index.js
+++ b/client/components/content-elements/tce-scorm/server/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { beforeSave } = require('@extensionengine/tce-scorm/dist/util');
+const { beforeSave } = require('@extensionengine/tce-scorm/dist/server');
 const { options } = require('@extensionengine/tce-scorm/dist/tce-scorm');
 
 module.exports = { type: options.type, beforeSave };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2284,8 +2284,8 @@
       }
     },
     "@extensionengine/tce-scorm": {
-      "version": "github:ExtensionEngine/tce-scorm#41efb8ca1dfddd27ae1fe58a8f8d3b3fe58edb68",
-      "from": "github:ExtensionEngine/tce-scorm#41efb8ca1dfddd2",
+      "version": "github:ExtensionEngine/tce-scorm#85d39a8d73f303f74f8d45b9e395f98346586b1c",
+      "from": "github:ExtensionEngine/tce-scorm#85d39a8d73f303f",
       "requires": {
         "fast-xml-parser": "^3.17.5",
         "lodash": "^4.17.20",
@@ -9086,9 +9086,9 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fast-xml-parser": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.17.5.tgz",
-      "integrity": "sha512-lEvThd1Xq+CCylf1n+05bUZCDZjTufaaaqpxM3JZ+4iDqtlG+d/oKgtMmg9GEMOuzBgUoalIzFOaClht9YiGJQ=="
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.18.0.tgz",
+      "integrity": "sha512-tRrwShhppv0K5GKEtuVs92W0VGDaVltZAwtHbpjNF+JOT7cjIFySBGTEOmdBslXYyWYaZwEX/g4Su8ZeKg0LKQ=="
     },
     "fastest-levenshtein": {
       "version": "1.0.12",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@extensionengine/tce-jodit": "github:extensionengine/tce-jodit#eede0d3b144c29b",
-    "@extensionengine/tce-scorm": "github:ExtensionEngine/tce-scorm#41efb8ca1dfddd2",
+    "@extensionengine/tce-scorm": "github:ExtensionEngine/tce-scorm#85d39a8d73f303f",
     "@mdi/font": "^4.8.95",
     "@ungap/global-this": "^0.4.0",
     "JSONStream": "^1.3.5",


### PR DESCRIPTION
### This PR:
- updates server source path according to #710 

Notes:
- 🚫 depends on [tce-scorm#1](https://github.com/ExtensionEngine/tce-scorm/pull/1), package needs to be bumped after it's merged
- this is currently patched in `tce-scorm/server` wrapper so it should be working even without this change