### PR TITLE
Ensure selected activity parents are always expanded

### DIFF
--- a/client/components/repository/Outline/index.vue
+++ b/client/components/repository/Outline/index.vue
@@ -49,12 +49,12 @@
 </template>
 
 <script>
-import { mapActions, mapGetters } from 'vuex';
 import Activity from './Activity';
 import Draggable from 'vuedraggable';
 import filter from 'lodash/filter';
 import find from 'lodash/find';
 import map from 'lodash/map';
+import { mapGetters } from 'vuex';
 import OutlineFooter from './OutlineFooter';
 import reorderMixin from './reorderMixin';
 import SearchResult from './SearchResult';
@@ -91,11 +91,9 @@ export default {
     }
   },
   methods: {
-    ...mapActions('repository', ['expandParents']),
     goTo(activity) {
       this.search = '';
       this.selectActivity(activity.id);
-      this.expandParents(activity);
       this.scrollToActivity(activity);
     },
     scrollToActivity(activity, timeout = 500) {

--- a/client/components/repository/index.vue
+++ b/client/components/repository/index.vue
@@ -81,21 +81,23 @@ export default {
   },
   methods: mapActions('repository', ['initialize', 'expandParents']),
   watch: {
-    selectedActivity(val) {
-      if (val) this.lastSelectedActivity = val;
+    selectedActivity: {
+      handler(val) {
+        if (!val) return;
+        this.lastSelectedActivity = val;
+        this.expandParents(val);
+      },
+      immediate: true
     }
   },
   async created() {
     const { repositoryId } = this;
     await this.initialize(repositoryId);
     this.showLoader = false;
-    if (!this.activities.length) return;
-    if (!this.selectedActivity) {
-      const rootActivities = filter(this.activities, { parentId: null });
-      const [activity] = sortBy(rootActivities, 'position');
-      this.selectActivity(activity.id);
-    }
-    this.expandParents(this.selectedActivity);
+    if (!this.activities.length || this.selectActivity) return;
+    const rootActivities = filter(this.activities, { parentId: null });
+    const [activity] = sortBy(rootActivities, 'position');
+    this.selectActivity(activity.id);
   },
   components: { ActiveUsers }
 };

--- a/client/components/repository/index.vue
+++ b/client/components/repository/index.vue
@@ -94,7 +94,7 @@ export default {
     const { repositoryId } = this;
     await this.initialize(repositoryId);
     this.showLoader = false;
-    if (!this.activities.length || this.selectActivity) return;
+    if (!this.activities.length || this.selectedActivity) return;
     const rootActivities = filter(this.activities, { parentId: null });
     const [activity] = sortBy(rootActivities, 'position');
     this.selectActivity(activity.id);

--- a/client/store/modules/repository/mutations.js
+++ b/client/store/modules/repository/mutations.js
@@ -14,7 +14,7 @@ export const toggleActivity = (state, { uid, expanded }) => {
 
 export const expandParents = (state, parents) => {
   const expanded = transform(parents, (acc, it) => (acc[it.uid] = true), {});
-  state.outline.expanded = expanded;
+  state.outline.expanded = { ...state.outline.expanded, ...expanded };
 };
 
 export const toggleActivities = (state, outline) => {


### PR DESCRIPTION
### This PR:
- expands selected activity parents without collapsing other expanded activities
- fixes issue when navigating to structure page after changing selected activity in either Progress or Graph views
- resolves #731 