### PR TITLE
Improve silent auth

### DIFF
--- a/server/oidc/index.js
+++ b/server/oidc/index.js
@@ -2,6 +2,7 @@
 
 const { authenticate, logout } = require('../shared/auth');
 const { BAD_REQUEST } = require('http-status-codes');
+const get = require('lodash/get');
 const { errors: OIDCError } = require('openid-client');
 const path = require('path');
 const router = require('express').Router();
@@ -31,7 +32,8 @@ const getSilentAuthParams = req => {
   const strategy = req.passport.strategy('oidc');
   const callbackUri = new URL(strategy.options.callbackURL);
   callbackUri.searchParams.set('silent', 'true');
-  return { redirect_uri: callbackUri.href };
+  const idToken = get(req.authData, 'oidc.tokenSet.id_token');
+  return { redirect_uri: callbackUri.href, id_token_hint: idToken };
 };
 
 const isOIDCError = err => OIDCErrors.some(Ctor => err instanceof Ctor);


### PR DESCRIPTION
### This PR:
- includes `id_token_hint` in auth request when doing silent authentication. Check [OIDC Spec](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) for more info

### QA notes:
This should fix login with Google. Two caveats still exist that cannot be easily handled with current implementation:
- If you clear cookies on Tailor and have more than one logged-in Google account you will have to re-login
- Logout from Google is still possible only by consuming global Google logout. After that user has to manually navigate back to Tailor
- Please do a regression with Okta and Auth0 as well. Thy