### PR TITLE
Fix element layout shift on selection

### DIFF
--- a/client/assets/stylesheets/common/_variables.scss
+++ b/client/assets/stylesheets/common/_variables.scss
@@ -11,5 +11,6 @@ $font-family-primary: Poppins, Helvetica, Arial, sans-serif;
 $font-family-secondary: Roboto, Helvetica, Arial, sans-serif;
 
 @mixin highlight($color) {
+  border: none;
   box-shadow: 0 0 0 2px $color !important;
 }

--- a/client/components/common/tce-core/ContentElement.vue
+++ b/client/components/common/tce-core/ContentElement.vue
@@ -139,6 +139,7 @@ export default {
   $accent-2: #ff4081;
 
   position: relative;
+  border: 1px solid transparent;
 
   &::after {
     $width: 0.125rem;
@@ -173,7 +174,7 @@ export default {
 
 .frame {
   padding: 10px 20px;
-  box-shadow: 0 0 0 1px #e1e1e1;
+  border: 1px solid #e1e1e1;
 }
 
 .element-actions {


### PR DESCRIPTION
### This PR:
- fixes minor content shift when element is focused/selected, caused by shadows and borders