### PR TITLE
Improve Resource helper

### DIFF
--- a/client/store/helpers/resource.js
+++ b/client/store/helpers/resource.js
@@ -88,7 +88,7 @@ export default class Resource {
    * @param {object} changes - Key-value collection of properties to update.
    */
   update(uid, changes) {
-    const id = this.mappings[uid];
+    const id = changes.id || this.mappings[uid];
     return this.patch(id, changes).then(extractData);
   }
 

--- a/client/store/helpers/resource.js
+++ b/client/store/helpers/resource.js
@@ -60,7 +60,9 @@ export default class Resource {
    * Retrieves model by id.
    */
   getById(id) {
-    return this.get(id).then(extractData);
+    return this.get(id)
+      .then(extractData)
+      .then(item => this.processEntries([item]) && item);
   }
 
   /**


### PR DESCRIPTION
This PR aims to resolve issues when the store collection `update` helper is invoked w/o fetching items first by:
- Adding `id`-`uid` mapping after `getById`
- Favoring `id` from the model (if present) in `update`

@underscope Even though either of these two changes fixes the issue I believe it would be good to do both to be on the safe side for any future use-cases. Thoughts?

Closes #740 