### PR TITLE
Fix activity repository_id foreign key error on repository import

### DIFF
--- a/server/activity/activity.model.js
+++ b/server/activity/activity.model.js
@@ -75,28 +75,28 @@ class Activity extends Model {
   }
 
   static async create(data, opts) {
-    return this.sequelize.transaction(async t => {
-      const transaction = opts.transaction || t;
-      const activity = await super.create(data, { ...opts, transaction });
-      if (activity.isTrackedInWorkflow) {
-        const defaultStatus = getDefaultActivityStatus(activity.type);
-        await activity.createStatus(defaultStatus, { transaction });
-      }
-      return activity;
-    });
+    return this.sequelize.transaction({ transaction: opts.transaction },
+      async transaction => {
+        const activity = await super.create(data, { ...opts, transaction });
+        if (activity.isTrackedInWorkflow) {
+          const defaultStatus = getDefaultActivityStatus(activity.type);
+          await activity.createStatus(defaultStatus, { transaction });
+        }
+        return activity;
+      });
   }
 
   static async bulkCreate(data, opts) {
-    return this.sequelize.transaction(async t => {
-      const transaction = opts.transaction || t;
-      const activities = await super.bulkCreate(data, { ...opts, transaction });
-      const statusData = activities
-        .filter(it => it.isTrackedInWorkflow)
-        .map(getDefaultStatus);
-      const ActivityStatus = this.sequelize.model('ActivityStatus');
-      await ActivityStatus.bulkCreate(statusData, { transaction });
-      return activities;
-    });
+    return this.sequelize.transaction({ transaction: opts.transaction },
+      async transaction => {
+        const activities = await super.bulkCreate(data, { ...opts, transaction });
+        const statusData = activities
+          .filter(it => it.isTrackedInWorkflow)
+          .map(getDefaultStatus);
+        const ActivityStatus = this.sequelize.model('ActivityStatus');
+        await ActivityStatus.bulkCreate(statusData, { transaction });
+        return activities;
+      });
   }
 
   static associate({ ActivityStatus, ContentElement, Comment, Repository }) {

--- a/server/activity/activity.model.js
+++ b/server/activity/activity.model.js
@@ -75,18 +75,20 @@ class Activity extends Model {
   }
 
   static async create(data, opts) {
-    return this.sequelize.transaction(async transaction => {
+    return this.sequelize.transaction(async t => {
+      const transaction = opts.transaction || t;
       const activity = await super.create(data, { ...opts, transaction });
       if (activity.isTrackedInWorkflow) {
         const defaultStatus = getDefaultActivityStatus(activity.type);
         await activity.createStatus(defaultStatus, { transaction });
       }
       return activity;
-    }, { transaction: opts.transaction });
+    });
   }
 
   static async bulkCreate(data, opts) {
-    return this.sequelize.transaction(async transaction => {
+    return this.sequelize.transaction(async t => {
+      const transaction = opts.transaction || t;
       const activities = await super.bulkCreate(data, { ...opts, transaction });
       const statusData = activities
         .filter(it => it.isTrackedInWorkflow)
@@ -94,7 +96,7 @@ class Activity extends Model {
       const ActivityStatus = this.sequelize.model('ActivityStatus');
       await ActivityStatus.bulkCreate(statusData, { transaction });
       return activities;
-    }, { transaction: opts.transaction });
+    });
   }
 
   static associate({ ActivityStatus, ContentElement, Comment, Repository }) {


### PR DESCRIPTION
This PR:
- ~changes `Activity#bulkCreate` to use transaction from options by default~
- fixes the order of arguments for `sequelize#transaction`

This fixes the issue with import breaking with the `repository_id` foreign key constraint error.
`Activity#bulkCreate` was running in different isolation scope from the import job because it was spawning new transaction.
