### PR TITLE
Pass context to the element hooks

### DIFF
--- a/server/content-element/hooks.js
+++ b/server/content-element/hooks.js
@@ -55,13 +55,13 @@ function add(ContentElement, Hooks, Models) {
     return Comment.update({ activityId: null }, options);
   }
 
-  function customElementHook(hookType, element) {
+  function customElementHook(hookType, element, options) {
     const elementHookTypes = elementHookMappings[hookType];
     if (!elementHookTypes) return;
     return Promise.resolve(elementHookTypes)
       .map(hook => elementRegistry.getHook(element.type, hook))
       .filter(Boolean)
-      .reduce((result, hook) => hook(result), element);
+      .reduce((result, hook) => hook(result, options.context), element);
   }
 
   function processAssets(hookType, element) {

--- a/server/content-element/hooks.js
+++ b/server/content-element/hooks.js
@@ -61,7 +61,7 @@ function add(ContentElement, Hooks, Models) {
     return Promise.resolve(elementHookTypes)
       .map(hook => elementRegistry.getHook(element.type, hook))
       .filter(Boolean)
-      .reduce((result, hook) => hook(result, options.context), element);
+      .reduce((result, hook) => hook(result, options), element);
   }
 
   function processAssets(hookType, element) {

--- a/server/shared/content-plugins/elementRegistry.js
+++ b/server/shared/content-plugins/elementRegistry.js
@@ -38,7 +38,7 @@ class ElementsRegistry extends BaseRegistry {
     const elementHooks = this._hooks[type];
     if (!elementHooks || !elementHooks[hook]) return;
     const services = { config, storage, storageProxy };
-    return element => elementHooks[hook](element, services);
+    return (element, context) => elementHooks[hook](element, services, context);
   }
 
   buildStaticsHandler() {

--- a/server/shared/content-plugins/elementRegistry.js
+++ b/server/shared/content-plugins/elementRegistry.js
@@ -38,7 +38,7 @@ class ElementsRegistry extends BaseRegistry {
     const elementHooks = this._hooks[type];
     if (!elementHooks || !elementHooks[hook]) return;
     const services = { config, storage, storageProxy };
-    return (element, context) => elementHooks[hook](element, services, context);
+    return (element, options) => elementHooks[hook](element, services, options);
   }
 
   buildStaticsHandler() {


### PR DESCRIPTION
**This PR **
Fixes diff preview for tce-sprout-video by passing context to the element hooks.