### PR TITLE
Fix: Image not visible on all slides inside the carousel element

### DIFF
--- a/client/components/content-elements/tce-image/edit/index.vue
+++ b/client/components/content-elements/tce-image/edit/index.vue
@@ -31,6 +31,7 @@
         v-show="!showCropper"
         :src="currentImage"
         :aspect-ratio="aspectRatio"
+        :max-width="elementWidth"
         class="mx-auto">
         <template v-slot:placeholder>
           <v-row
@@ -158,6 +159,10 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.tce-image {
+  max-width: 100%;
+}
+
 .hide-cropper ::v-deep .cropper-container {
   display: none;
 }

--- a/client/components/content-elements/tce-image/edit/index.vue
+++ b/client/components/content-elements/tce-image/edit/index.vue
@@ -159,10 +159,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.tce-image {
-  max-width: 100%;
-}
-
 .hide-cropper ::v-deep .cropper-container {
   display: none;
 }

--- a/client/components/content-elements/tce-image/edit/index.vue
+++ b/client/components/content-elements/tce-image/edit/index.vue
@@ -31,7 +31,6 @@
         v-show="!showCropper"
         :src="currentImage"
         :aspect-ratio="aspectRatio"
-        :max-width="maxWidth"
         class="mx-auto">
         <template v-slot:placeholder>
           <v-row
@@ -82,12 +81,7 @@ export default {
     isDisabled: { type: Boolean, default: false },
     dense: { type: Boolean, default: false }
   },
-  data: () => ({
-    containerWidth: 0,
-    currentImage: null,
-    persistedImage: null,
-    showCropper: false
-  }),
+  data: () => ({ currentImage: null, persistedImage: null, showCropper: false }),
   computed: {
     showPlaceholder() {
       const imageAvailable = !isEmpty(this.element.data.url);
@@ -95,10 +89,8 @@ export default {
       if (this.$refs.cropper) this.$refs.cropper.destroy();
       return true;
     },
-    elementWidth: ({ containerWidth, element }) => element.data.meta?.width,
-    elementHeight: ({ containerWidth, element }) => element.data.meta?.height,
-    maxWidth: ({ containerWidth, elementWidth }) =>
-      containerWidth > elementWidth ? elementWidth : containerWidth,
+    elementWidth: ({ element }) => element.data.meta?.width,
+    elementHeight: ({ element }) => element.data.meta?.height,
     aspectRatio: ({ elementHeight, elementWidth }) =>
       elementHeight && elementWidth && (elementWidth / elementHeight)
   },
@@ -129,7 +121,6 @@ export default {
     }
   },
   mounted() {
-    this.containerWidth = this.$el.parentElement.offsetWidth;
     this.load(this.element.data.url);
 
     this.$elementBus.on('upload', dataUrl => {


### PR DESCRIPTION
Fixes #726

Before:
![Kapture 2021-02-23 at 12 02 31](https://user-images.githubusercontent.com/26693037/108834916-05bec300-75cf-11eb-8481-a6a215a2e692.gif)


After:
![Kapture 2021-02-23 at 11 59 59](https://user-images.githubusercontent.com/26693037/108834630-af518480-75ce-11eb-9f2c-859a56cd2c25.gif)

QA note:
- this PR affects the `tce-image` and all elements which use `tce-image` embeds.