### PR TITLE
Fixed issue with publishing diff date chip text color

### DIFF
--- a/client/components/editor/Toolbar/index.vue
+++ b/client/components/editor/Toolbar/index.vue
@@ -15,7 +15,11 @@
           <span class="px-2 grey--text">|</span>
           <span class="white--text">comparing with published</span>
           <span class="px-2 grey--text">@</span>
-          <v-chip color="readonly primary lighten-4" small label>
+          <v-chip
+            color="primary lighten-4"
+            text-color="grey darken-4"
+            small label
+            class="readonly">
             {{ activity.publishedAt | formatDate }}
           </v-chip>
         </template>


### PR DESCRIPTION
Prev version =>
![image](https://user-images.githubusercontent.com/6253820/110310450-da8e9780-8002-11eb-8579-3c6a1294d2ac.png)

Updated to =>
![image](https://user-images.githubusercontent.com/6253820/110310403-ccd91200-8002-11eb-8a34-24a682143a6e.png)
