### PR TITLE
History revisions style improvements

### DIFF
--- a/client/components/repository/Revisions/EntityRevisions.vue
+++ b/client/components/repository/Revisions/EntityRevisions.vue
@@ -106,7 +106,6 @@ export default {
   .preview {
     flex-grow: 1;
     min-width: 300px;
-    min-height: 500px;
     margin-right: 16px;
     text-align: center;
   }
@@ -123,5 +122,11 @@ export default {
   height: 0;
   padding-top: 0;
   padding-bottom: 0;
+}
+
+::v-deep {
+  .content-element.frame {
+    height: 100%;
+  }
 }
 </style>

--- a/client/components/repository/Revisions/index.vue
+++ b/client/components/repository/Revisions/index.vue
@@ -81,7 +81,6 @@ export default {
   text-align: left;
 
   ul {
-    max-width: 100%;
     padding: 0.5rem;
     list-style-type: none;
 

--- a/client/components/repository/Revisions/index.vue
+++ b/client/components/repository/Revisions/index.vue
@@ -81,8 +81,8 @@ export default {
   text-align: left;
 
   ul {
-    max-width: 75rem;
-    padding: 0.5rem 0;
+    max-width: 100%;
+    padding: 0.5rem;
     list-style-type: none;
 
     li {


### PR DESCRIPTION
### This PR
- [x] Closes #762 
- [x] Makes revision list full width and adds additional .5rem padding on left and right
- [x] Removes min-height from content-element from to not introduces additional white space