### PR TITLE
Feature flag OIDC logout via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,7 @@ OIDC_JWKS_URL=
 OIDC_AUTHORIZATION_ENDPOINT=
 OIDC_TOKEN_ENDPOINT=
 OIDC_USERINFO_ENDPOINT=
+OIDC_LOGOUT_ENABLED=1
 OIDC_LOGOUT_ENDPOINT=
 # Use OIDC_POST_LOGOUT_URI_KEY if OIDC provider uses post logout uri key not
 # aligned with OIDC RP-Initiated Logout standard key (post_logout_redirect_uri)

--- a/client/OidcClient.js
+++ b/client/OidcClient.js
@@ -7,6 +7,7 @@ const SILENT_REFRESH_TIMEOUT = 5000;
 class OidcClient {
   constructor() {
     this.enabled = process.env.OIDC_ENABLED;
+    this.logoutEnabled = process.env.OIDC_LOGOUT_ENABLED;
     this.baseUrl = join(process.env.API_PATH, 'oidc');
   }
 

--- a/client/components/common/Navbar.vue
+++ b/client/components/common/Navbar.vue
@@ -81,7 +81,7 @@ export default {
   methods: {
     ...mapActions({ apiLogout: 'logout' }),
     logout() {
-      if (this.isOidcActive) return this.$oidc.logout();
+      if (this.isOidcActive && this.$oidc.logoutEnabled) return this.$oidc.logout();
       return this.apiLogout()
         .then(() => this.$router.push({ name: 'login' }));
     }

--- a/client/store/index.js
+++ b/client/store/index.js
@@ -32,7 +32,7 @@ export default function getStore() {
 }
 
 function hydrateUserStore() {
-  const authRefresh = Vue.oidc.enabled
+  const authRefresh = Vue.oidc.enabled && Vue.oidc.logoutEnabled
     ? Vue.oidc.slientlyRefresh().catch(() => {})
     : Promise.resolve();
 

--- a/poi.config.js
+++ b/poi.config.js
@@ -9,6 +9,7 @@ const {
   NODE_ENV,
   STORAGE_PATH,
   OIDC_ENABLED,
+  OIDC_LOGOUT_ENABLED,
   OIDC_LOGIN_TEXT
 } = process.env;
 const imagesPath = 'assets/img';
@@ -94,6 +95,7 @@ module.exports = {
     API_PATH: '/api',
     ENABLE_DEFAULT_SCHEMA: yn(ENABLE_DEFAULT_SCHEMA),
     OIDC_ENABLED: yn(OIDC_ENABLED),
+    OIDC_LOGOUT_ENABLED: yn(OIDC_LOGOUT_ENABLED),
     OIDC_LOGIN_TEXT
   },
   babel: {


### PR DESCRIPTION
This PR introduces a new environment variable `OIDC_LOGOUT_ENABLED`.
If set to a truthy value it will reduce logout to be only local and disable silent auth.
The motivation behind this is to enable using OIDC login with IdPs that do not support ODIC RP Initiate Logout protocol/spec (e.g. Google).
The caveat of opting for this approach is obvious (no silent auth) so it is set to `1` in `.env.example` to act as a default example value.