### PR TITLE
Fix broken activity delete action, hide discussion on empty progress page

### DIFF
--- a/client/components/repository/Workflow/Sidebar/index.vue
+++ b/client/components/repository/Workflow/Sidebar/index.vue
@@ -20,7 +20,11 @@
       <v-icon>mdi-chevron-left</v-icon>
       <div class="info-content">{{ emptyMessage }}</div>
     </section>
-    <activity-discussion :activity="selectedActivity" panel class="mt-2 mb-5 mx-1" />
+    <activity-discussion
+      v-if="selectedActivity"
+      :activity="selectedActivity"
+      panel
+      class="mt-2 mb-5 mx-1" />
   </v-navigation-drawer>
 </template>
 

--- a/client/store/helpers/mutations.js
+++ b/client/store/helpers/mutations.js
@@ -30,6 +30,10 @@ export const save = (state, model) => {
   Vue.set(state.items, model.uid, model);
 };
 
+export const saveAll = (state, models) => {
+  each(models, it => save(state, it));
+};
+
 export const remove = (state, models) => {
   models.forEach(it => Vue.delete(state.items, it.uid));
 };

--- a/client/store/helpers/mutations.js
+++ b/client/store/helpers/mutations.js
@@ -1,3 +1,4 @@
+import castArray from 'lodash/castArray';
 import each from 'lodash/each';
 import omit from 'lodash/omit';
 import uuid from '@/utils/uuid';
@@ -24,14 +25,12 @@ export const update = (state, model) => {
   Vue.set(state.items, existing.uid, { ...existing, ...omit(model, 'uid') });
 };
 
-export const save = (state, model) => {
-  const existing = state.items[model.uid];
-  if (existing) return update(state, model);
-  Vue.set(state.items, model.uid, model);
-};
-
-export const saveAll = (state, models) => {
-  each(models, it => save(state, it));
+export const save = (state, models) => {
+  castArray(models).forEach(model => {
+    const existing = state.items[model.uid];
+    if (existing) return update(state, model);
+    Vue.set(state.items, model.uid, model);
+  });
 };
 
 export const remove = (state, models) => {

--- a/client/store/modules/repository/activities/actions.js
+++ b/client/store/modules/repository/activities/actions.js
@@ -14,7 +14,7 @@ const plugSSE = ({ commit }) => {
   feed
     .subscribe(Events.Create, item => commit('save', item))
     .subscribe(Events.Update, item => commit('save', item))
-    .subscribe(Events.BulkUpdate, items => commit('saveAll', items))
+    .subscribe(Events.BulkUpdate, items => commit('save', items))
     .subscribe(Events.Delete, item => commit('remove', [item]));
 };
 

--- a/client/store/modules/repository/activities/actions.js
+++ b/client/store/modules/repository/activities/actions.js
@@ -14,6 +14,7 @@ const plugSSE = ({ commit }) => {
   feed
     .subscribe(Events.Create, item => commit('save', item))
     .subscribe(Events.Update, item => commit('save', item))
+    .subscribe(Events.BulkUpdate, items => commit('saveAll', items))
     .subscribe(Events.Delete, item => commit('remove', [item]));
 };
 

--- a/client/store/modules/repository/activities/mutations.js
+++ b/client/store/modules/repository/activities/mutations.js
@@ -1,9 +1,9 @@
 import {
-  add, fetch, remove, reset, save, saveAll, setEndpoint
+  add, fetch, remove, reset, save, setEndpoint
 } from '@/store/helpers/mutations';
 
 const reorder = (state, { activity, position }) => {
   state.items[activity.uid].position = position;
 };
 
-export { add, fetch, remove, reorder, reset, save, saveAll, setEndpoint };
+export { add, fetch, remove, reorder, reset, save, setEndpoint };

--- a/client/store/modules/repository/activities/mutations.js
+++ b/client/store/modules/repository/activities/mutations.js
@@ -1,9 +1,9 @@
 import {
-  add, fetch, remove, reset, save, setEndpoint
+  add, fetch, remove, reset, save, saveAll, setEndpoint
 } from '@/store/helpers/mutations';
 
 const reorder = (state, { activity, position }) => {
   state.items[activity.uid].position = position;
 };
 
-export { add, fetch, remove, reorder, reset, save, setEndpoint };
+export { add, fetch, remove, reorder, reset, save, saveAll, setEndpoint };

--- a/client/store/modules/repository/getters.js
+++ b/client/store/modules/repository/getters.js
@@ -60,7 +60,7 @@ export const workflow = (_state, { repository }) => {
 export const hasWorkflow = (_state, { workflow }) => Boolean(workflow);
 
 export const workflowActivities = (_state, { activities }) => {
-  return activities.filter(it => it.isTrackedInWorkflow);
+  return activities.filter(it => !it.detached && it.isTrackedInWorkflow);
 };
 
 export const isCollapsed = state => {

--- a/common/sse.js
+++ b/common/sse.js
@@ -3,6 +3,7 @@
 const Activity = {
   Create: 'activity:create',
   Update: 'activity:update',
+  BulkUpdate: 'activity:bulk_update',
   Delete: 'activity:delete'
 };
 

--- a/server/activity/activity.model.js
+++ b/server/activity/activity.model.js
@@ -278,11 +278,7 @@ class Activity extends Model {
 function removeAll(Model, where = {}, options = {}) {
   const { soft, transaction } = options;
   if (!soft) return Model.destroy({ where });
-  return Model.update({ detached: true }, {
-    where,
-    transaction,
-    individualHooks: true
-  });
+  return Model.update({ detached: true }, { where, transaction });
 }
 
 function getDefaultStatus({ id, type }) {

--- a/server/activity/hooks.js
+++ b/server/activity/hooks.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const forEach = require('lodash/forEach');
+const groupBy = require('lodash/groupBy');
 const { isOutlineActivity } = require('../../config/shared/activities');
 const sse = require('../shared/sse');
 
@@ -30,8 +31,10 @@ function add(Activity, Hooks, Models) {
 
   async function sseBulkUpdate(_, { where }) {
     const activities = await Models.Activity.findAll({ where });
-    const [activity] = activities;
-    sse.channel(activity.repositoryId).send(Events.BulkUpdate, activities);
+    const activitiesByRepository = groupBy(activities, 'repositoryId');
+    forEach(activitiesByRepository, (activities, repositoryId) => {
+      sse.channel(repositoryId).send(Events.BulkUpdate, activities);
+    });
   }
 
   async function sseDelete(_, activity) {


### PR DESCRIPTION
### This PR:
- fixes broken activity delete action (#799)
- state is hydrated with a single SSE after bulk activity update; previously SSE was sent per item
- discussion is hidden in the progress page's sidebar when there's no selected activity

⚠️ Issue was caused by Sequelize's `individualHooks` flag in the model methods. When used, it loads instances with the appropriate scopes before running the `update` query. In this case, it caused the bug which would assign included model's alias (from the default scope) to `update` query's column.

#### :mag: QA note:
This change affects functionalities that save data to the server (creating and updating elements, repositories, etc.)