### PR TITLE
Half width element issues fix & name format validation message enhancement

### DIFF
--- a/client/components/content-elements/tce-embed/edit/index.vue
+++ b/client/components/content-elements/tce-embed/edit/index.vue
@@ -49,7 +49,9 @@ export default {
     }
   },
   mounted() {
-    this.$elementBus.on('save', data => this.$emit('save', data));
+    this.$elementBus.on('save', data => {
+      this.$emit('save', { ...this.element.data, ...data });
+    });
   },
   components: {
     ElementPlaceholder,

--- a/client/components/content-elements/tce-html/edit/index.vue
+++ b/client/components/content-elements/tce-html/edit/index.vue
@@ -84,7 +84,8 @@ export default {
     },
     save() {
       if (!this.hasChanges) return;
-      this.$emit('save', { content: this.content });
+      const { content, element } = this;
+      this.$emit('save', { ...element.data, content });
     }
   },
   watch: {

--- a/client/components/content-elements/tce-image/edit/index.vue
+++ b/client/components/content-elements/tce-image/edit/index.vue
@@ -105,10 +105,9 @@ export default {
       this.persistedImage = imageUrl;
       if (imageUrl && this.$refs.cropper) this.$refs.cropper.replace(imageUrl);
     },
-    save(image) {
-      return getImageDimensions(image).then(({ width, height }) => {
-        this.$emit('save', { url: image, meta: { width, height } });
-      });
+    async save(image) {
+      const meta = await getImageDimensions(image);
+      this.$emit('save', { ...this.element.data, url: image, meta });
     }
   },
   watch: {

--- a/client/utils/validation.js
+++ b/client/utils/validation.js
@@ -13,8 +13,7 @@ const nameFormat = {
     const hasValidBoundaries = !/^['-.].*|['.-]$/.test(value);
     return hasValidUnicodeLetters && hasValidBoundaries && !hasPunctuationStreak;
   },
-  message: `The {_field_} field may only contain alphabetic characters, spaces,
-    dots (.), apostrophes (') and hyphens (-)`
+  message: 'The {_field_} field is not valid'
 };
 
 const alphanumerical = {


### PR DESCRIPTION
This Pr addresses #818
It fixes half width issue on remaining content elements:

- Image
- Embed
- Deprecated HTML (text)

Bonus:
- Simplified `name_format` validation message