### PR TITLE
Hide element toolbar on activity/editor change

### DIFF
--- a/client/components/editor/index.vue
+++ b/client/components/editor/index.vue
@@ -76,7 +76,12 @@ export default {
     });
     return { $editorState };
   },
-  watch: { activityId: 'closePublishDiff' },
+  watch: {
+    activityId() {
+      this.selectedElement = null;
+      this.closePublishDiff();
+    }
+  },
   async created() {
     const { repositoryId: currentRepositoryId, repository: storeRepository } = this;
     const repositoryLoaded = !!storeRepository;


### PR DESCRIPTION
- This PR addresses #821
- It clears `selected element` after activity/editor changes which automatically removes editor toolbar.

🔍  QA Note:
- Test every action thoroughly which can be affected after `editor` route (id) is changed