### PR TITLE
Limit the comment input to 600 chars

### DIFF
--- a/client/components/common/tce-core/Discussion/index.vue
+++ b/client/components/common/tce-core/Discussion/index.vue
@@ -67,6 +67,11 @@ import ResolveButton from './ResolveButton';
 
 const initCommentInput = () => ({ content: '' });
 
+const maxLength = input => {
+  if (!input) return true;
+  return input.length <= 600 || 'Max 600 characters';
+};
+
 export default {
   name: 'embedded-discussion',
   inheritAttrs: true,
@@ -88,7 +93,7 @@ export default {
     error: false
   }),
   computed: {
-    rules: () => [input => input.length <= 600 || 'Max 600 characters'],
+    rules: () => [maxLength],
     thread() {
       const { comments, unseenComments } = this;
       const processedThread = comments.map(comment => {

--- a/client/components/common/tce-core/Discussion/index.vue
+++ b/client/components/common/tce-core/Discussion/index.vue
@@ -46,11 +46,13 @@
         ref="commentInput"
         v-model.trim="comment.content"
         @focus="$emit('seen')"
+        @update:error="error = $event"
         :placeholder="commentsCount ? 'Add a comment...' : 'Start the discussion...'"
+        :rules="rules"
         rows="3"
         outlined auto-grow clearable counter
         class="comment-input" />
-      <v-btn @click="post" :disabled="isTextEditorEmpty" icon>
+      <v-btn @click="post" :disabled="isTextEditorEmpty || error" icon>
         <v-icon>mdi-send</v-icon>
       </v-btn>
     </div>
@@ -82,9 +84,11 @@ export default {
   },
   data: () => ({
     showAll: false,
-    comment: initCommentInput()
+    comment: initCommentInput(),
+    error: false
   }),
   computed: {
+    rules: () => [input => input.length <= 600 || 'Max 600 characters'],
     thread() {
       const { comments, unseenComments } = this;
       const processedThread = comments.map(comment => {


### PR DESCRIPTION
Closes #842.

Note 💡 
The request was to implement a counter in the form `{{ length }} / {{ max }}` but the current Vuetify version doesn't support a counter slot. The counter slot is available in version [2.4.11](https://vuetifyjs.com/en/api/v-textarea/#slots-counter).
That being said, after offline discussion we decided to schedule this request for Tailor version 5.1.

New:
![Screenshot 2021-05-05 at 11 15 35](https://user-images.githubusercontent.com/26693037/117120111-396a5600-ad93-11eb-8357-f74963651282.png)
![Screenshot 2021-05-05 at 11 15 51](https://user-images.githubusercontent.com/26693037/117120145-42f3be00-ad93-11eb-8633-1e0e3cb34b1f.png)

- 25 character limit is set only for cleaner screenshot