### PR TITLE
Run remove-user-token migration in a transaction

### DIFF
--- a/server/shared/database/migrations/20190717151916-remove-user-token.js
+++ b/server/shared/database/migrations/20190717151916-remove-user-token.js
@@ -6,17 +6,21 @@ const TABLE = 'user';
 
 module.exports = {
   up: async qi => {
-    await qi.removeColumn(TABLE, 'token');
-    await qi.changeColumn(TABLE, 'password', {
-      type: Sequelize.STRING,
-      allowNull: false
+    return qi.sequelize.transaction(async transaction => {
+      await qi.removeColumn(TABLE, 'token', { transaction });
+      await qi.changeColumn(TABLE, 'password', {
+        type: Sequelize.STRING,
+        allowNull: false
+      }, { transaction });
     });
   },
   down: async qi => {
-    await qi.addColumn(TABLE, 'token', { type: Sequelize.STRING, unique: true });
-    await qi.changeColumn(TABLE, 'password', {
-      type: Sequelize.STRING,
-      allowNull: true
+    return qi.sequelize.transaction(async transaction => {
+      await qi.addColumn(TABLE, 'token', { type: Sequelize.STRING, unique: true }, { transaction });
+      await qi.changeColumn(TABLE, 'password', {
+        type: Sequelize.STRING,
+        allowNull: true
+      }, { transaction });
     });
   }
 };


### PR DESCRIPTION
In the case where there are empty passwords the `changeColumn` command
for the `password` column would fail, but the `token` column would be
deleted causing `column "token" of relation "user" does not exist`
errors on new migration runs.