### PR TITLE
Stop linting the extensions folder

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 dist
+extensions

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,14 +18,6 @@ module.exports = {
       parserOptions: {
         sourceType: 'script'
       }
-    },
-    {
-      files: ['extensions/**'],
-      excludedFiles: ['extensions/content-elements/**/server/**'],
-      parserOptions: {
-        parser: '@babel/eslint-parser',
-        sourceType: 'module'
-      }
     }
   ],
   globals: {


### PR DESCRIPTION
Since the extensions folder should, by definition, contain the
third-party code, it doesn't make much sense to run the linter on it.
Especially since the build will fail if there are any linter errors,
which most certainly there will be if the extensions don't follow
exactly the same eslint rules as the tailor itself does.