### PR TITLE
Force the POSIX path separators in API routes

### DIFF
--- a/server/repository/index.js
+++ b/server/repository/index.js
@@ -62,7 +62,7 @@ mount(router, '/:repositoryId', comment);
 mount(router, '/:repositoryId', storageRouter);
 
 function mount(router, mountPath, subrouter) {
-  return router.use(path.join(mountPath, subrouter.path), subrouter.router);
+  return router.use(path.posix.join(mountPath, subrouter.path), subrouter.router);
 }
 
 function getRepository(req, _res, next, repositoryId) {


### PR DESCRIPTION
`path.join()` on its own will use a path separator of whatever the OS
the code is currently running on (e.g. "/" on Unix, "\\" on Windows). API
routes should always use a forward-slash as its path separator, and this
is what is done in this PR.

There are probably a couple of more instances in the codebase which
should always force the POSIX path separator, but I'll fix those once I
encounter them as I'm not sure where they are off the top of my head.