### PR TITLE
Update `tce-jodit` to include image uploader plugin

### DIFF
--- a/client/components/content-elements/tce-jodit/server/index.js
+++ b/client/components/content-elements/tce-jodit/server/index.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const { afterLoaded, beforeSave } = require('@extensionengine/tce-jodit/dist/server');
+const { tailor: options } = require('@extensionengine/tce-jodit/package.json');
+
+module.exports = {
+  type: options.type,
+  beforeSave,
+  afterLoaded
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -2340,11 +2340,12 @@
       }
     },
     "@extensionengine/tce-jodit": {
-      "version": "github:extensionengine/tce-jodit#c5464cdaec4681b03c84090d285a3ec2c9c43dbf",
-      "from": "github:extensionengine/tce-jodit#c5464cd",
+      "version": "github:droguljic/tce-jodit#4f611d4f8ab89cae069f2f4e02def0a86f2a922d",
+      "from": "github:droguljic/tce-jodit#4f611d4f8ab89ca",
       "requires": {
         "auto-bind": "^4.0.0",
         "brace": "^0.11.1",
+        "cuid": "^2.1.8",
         "jodit-vue": "^2.4.0",
         "js-beautify": "^1.13.13",
         "scrollparent": "^2.0.1"
@@ -2356,14 +2357,13 @@
           "integrity": "sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ=="
         },
         "js-beautify": {
-          "version": "1.13.13",
-          "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.13.13.tgz",
-          "integrity": "sha512-oH+nc0U5mOAqX8M5JO1J0Pw/7Q35sAdOsM5W3i87pir9Ntx6P/5Gx1xLNoK+MGyvHk4rqqRCE4Oq58H6xl2W7A==",
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.0.tgz",
+          "integrity": "sha512-yuck9KirNSCAwyNJbqW+BxJqJ0NLJ4PwBUzQQACl5O3qHMBXVkXb/rD0ilh/Lat/tn88zSZ+CAHOlk0DsY7GuQ==",
           "requires": {
             "config-chain": "^1.1.12",
             "editorconfig": "^0.15.3",
             "glob": "^7.1.3",
-            "mkdirp": "^1.0.4",
             "nopt": "^5.0.0"
           }
         }
@@ -16456,9 +16456,9 @@
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "jodit": {
-      "version": "3.6.17",
-      "resolved": "https://registry.npmjs.org/jodit/-/jodit-3.6.17.tgz",
-      "integrity": "sha512-zwmh71xJYzF+yiwltNgG+RrwQ5rXtbe1r2TiwtBbv8AxbMj3pqQYxw1VqKQRxKEr7FQMR0qAhP44Bel6m8pvOg==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jodit/-/jodit-3.7.1.tgz",
+      "integrity": "sha512-C1DMa+ar47GJhubukhs6Q1VD6nvDK3JpSNszDnE3iVrkDk7mtu8N4bosos1Brhu4qaYMySlAOun8zz4KTePB1A==",
       "requires": {
         "autobind-decorator": "^2.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@extensionengine/tapster": "github:ExtensionEngine/tapster#53ccb222c757948d322c33087620453ddf5e70ed",
-    "@extensionengine/tce-jodit": "github:extensionengine/tce-jodit#c5464cd",
+    "@extensionengine/tce-jodit": "github:droguljic/tce-jodit#4f611d4f8ab89ca",
     "@extensionengine/tce-scorm": "github:ExtensionEngine/tce-scorm#85d39a8d73f303f",
     "@extensionengine/vue-radio": "^0.1.5",
     "@mdi/font": "^4.8.95",


### PR DESCRIPTION
Update `tce-jodit` in order to utilize the new image uploader plugin
which enables upload of images through Tailor's storage service.
This functionality is exposed through the `Upload` tab on the image popup.

##### NOTE: Do not merge before [this PR is merged](https://github.com/ExtensionEngine/tce-jodit/pull/16), and afterwards point `tce-jodit` to a new commit hash. 