### PR TITLE
Encode filename in source key on Storage#copyFile

### DIFF
--- a/server/shared/storage/providers/amazon.js
+++ b/server/shared/storage/providers/amazon.js
@@ -77,8 +77,13 @@ class Amazon {
 
   // API docs: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#copyObject-property
   copyFile(key, newKey, options = {}) {
+    const { base, ...rest } = path.parse(key);
+    const encodedSource = path.format({
+      base: encodeURIComponent(base),
+      ...rest
+    });
     const params = Object.assign(options, { Bucket: this.bucket }, {
-      CopySource: this.path(`/${key}`),
+      CopySource: this.path(`/${encodedSource}`),
       Key: newKey
     });
     return this.client.copyObject(params).promise();


### PR DESCRIPTION
This PR encodes the filename part of the Amazon s3 storage source path in Storage#copyFile to be aligned with [AWS S3 docs](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html#API_CopyObject_RequestSyntax).

Currently, filenames are sent w/o URL encoding which makes asset migration script fail for assets that contain URL reserved characters in their filenames (e.g. '+').

Resolves #929 