### PR TITLE
Implement repository/activity/content element clone/copy functionality

### DIFF
--- a/server/repository/repository.model.js
+++ b/server/repository/repository.model.js
@@ -131,7 +131,7 @@ class Repository extends Model {
       const src = await Activity.findAll({
         where: { repositoryId: this.id, parentId: null }, transaction
       });
-      const idMap = await Activity.cloneActivities(src, dst.id, null, { context, transaction });
+      const idMap = await Activity.cloneActivities(src, dst, null, { context, transaction });
       await dst.mapClonedReferences(idMap, transaction);
       return dst;
     });

--- a/server/script/migrateAssetsLocation.js
+++ b/server/script/migrateAssetsLocation.js
@@ -10,14 +10,13 @@ const {
 const get = require('lodash/get');
 const getFileMetas = require('../shared/util/getFileMetas');
 const Listr = require('listr');
-const path = require('path');
 const Promise = require('bluebird');
 const { protocol } = require('../../config/server/storage');
+const resolveNewURL = require('../shared/util/resolveNewURL');
 const { SCHEMAS } = require('../../config/shared/activities');
 const storage = require('../repository/storage');
 const toPairs = require('lodash/toPairs');
 
-const ASSET_PATH_REGEX = /(?<directory>repository\/assets\/(?<fileName>[^?]*))/;
 const CHUNK_SIZE = 2000;
 const IMAGE_ELEMENT_TYPE = 'IMAGE';
 
@@ -252,13 +251,4 @@ class RepositoryMigration {
     }, {});
     return { ...metaInputs, ...newMeta };
   }
-}
-
-function resolveNewURL(assetUrl, targetDir) {
-  if (assetUrl.startsWith(protocol)) assetUrl = assetUrl.substr(protocol.length);
-  const result = assetUrl.match(ASSET_PATH_REGEX);
-  if (!result) return;
-  const { groups: { directory, fileName } } = result;
-  const newKey = path.join(targetDir, fileName);
-  return { key: directory, newKey };
 }

--- a/server/script/migrateAssetsLocation.js
+++ b/server/script/migrateAssetsLocation.js
@@ -18,6 +18,7 @@ const toPairs = require('lodash/toPairs');
 
 const ASSET_PATH_REGEX = /(?<directory>repository\/assets\/(?<fileName>[^?]*))/;
 const CHUNK_SIZE = 2000;
+const IMAGE_ELEMENT_TYPE = 'IMAGE';
 
 const ENTITIES = {
   REPOSITORY: 'REPOSITORY',
@@ -154,7 +155,7 @@ class RepositoryMigration {
 
   async migrateContentElementData(element) {
     const { type, data } = element;
-    if (type === 'IMAGE') return this.imageMigrationHandler(element);
+    if (type === IMAGE_ELEMENT_TYPE) return this.imageMigrationHandler(element);
     const embeds = data.embeds && (await this.embedsMigrationHandler(element));
     const assets = data.assets && (await this.defaultMigrationHandler(element));
     return { ...data, ...embeds, ...assets };

--- a/server/shared/util/cloneContentElement.js
+++ b/server/shared/util/cloneContentElement.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const cloneFileMeta = require('./cloneFileMeta');
+const get = require('lodash/get');
+const Promise = require('bluebird');
+const { protocol } = require('../../../config/server/storage');
+const resolveAssetURL = require('./resolveAssetURL');
+const storage = require('../../repository/storage');
+const toPairs = require('lodash/toPairs');
+
+const IMAGE_ELEMENT_TYPE = 'IMAGE';
+
+async function embedsMigrationHandler(element, repositoryAssetsPath) {
+  const { repositoryId, data } = element;
+  const embeds = await Promise.reduce(Object.entries(data.embeds), async (acc, [id, embed]) => {
+    const payload = await cloneContentElement({ repositoryId, ...embed }, repositoryAssetsPath);
+    return { ...acc, [id]: { ...embed, ...payload } };
+  }, {});
+  return { embeds };
+}
+
+async function defaultMigrationHandler({ data }, repositoryAssetsPath) {
+  const updatedAssets = await Promise
+    .filter(toPairs(data.assets), ([_, value]) => value.startsWith(protocol))
+    .reduce(async (acc, [key, value]) => {
+      const { key: oldKey, newKey } = resolveAssetURL(value, repositoryAssetsPath) || {};
+      if (!oldKey || !newKey) return { ...acc, [key]: value };
+      await storage.copyFile(oldKey, newKey);
+      return { ...acc, [key]: `${protocol}${newKey}` };
+    }, {});
+  return { assets: { ...data.assets, ...updatedAssets } };
+}
+
+async function imageMigrationHandler({ data }, repositoryAssetsPath) {
+  const url = get(data, 'url');
+  if (!url) return data;
+  const { key, newKey } = resolveAssetURL(url, repositoryAssetsPath) || {};
+  if (!key || !newKey) return data;
+  await storage.copyFile(key, newKey);
+  return { ...data, url: newKey };
+}
+
+async function migrateData(element, repositoryAssetsPath) {
+  const { type, data } = element;
+  if (type === IMAGE_ELEMENT_TYPE) return imageMigrationHandler(element, repositoryAssetsPath);
+  const embeds = data.embeds && (await embedsMigrationHandler(element, repositoryAssetsPath));
+  const assets = data.assets && (await defaultMigrationHandler(element, repositoryAssetsPath));
+  return { ...data, ...embeds, ...assets };
+}
+
+async function migrateMeta(element, repositoryAssetsPath, metaByElementType) {
+  const { type, meta: metaInputs } = element;
+  const metaConfigs = get(metaByElementType, type, []);
+  return cloneFileMeta(metaInputs, metaConfigs, repositoryAssetsPath);
+}
+
+async function cloneContentElement(element, repositoryAssetsPath, metaByElementType) {
+  const data = await migrateData(element, repositoryAssetsPath);
+  const meta = await migrateMeta(element, repositoryAssetsPath, metaByElementType);
+  return { data, meta };
+}
+
+module.exports = cloneContentElement;

--- a/server/shared/util/cloneFileMeta.js
+++ b/server/shared/util/cloneFileMeta.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const get = require('lodash/get');
+const Promise = require('bluebird');
+const { protocol } = require('../../../config/server/storage');
+const resolveAssetURL = require('./resolveAssetURL');
+const storage = require('../../repository/storage');
+
+module.exports = async (metaInputs, metaConfigs, repositoryAssetsPath) => {
+  const newMeta = await Promise.reduce(metaConfigs, async (acc, metaKey) => {
+    const meta = get(metaInputs, metaKey);
+    if (!meta) return acc;
+    const url = get(meta, 'url');
+    if (!url) return acc;
+    const { key, newKey } = resolveAssetURL(url, repositoryAssetsPath) || {};
+    if (!key || !newKey) return acc;
+    await storage.copyFile(key, newKey);
+    return {
+      ...acc,
+      [metaKey]: {
+        ...meta,
+        key: newKey,
+        url: `${protocol}${newKey}`
+      }
+    };
+  }, {});
+  return { ...metaInputs, ...newMeta };
+};

--- a/server/shared/util/getFileMetas.js
+++ b/server/shared/util/getFileMetas.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const FILE_ELEMENT_TYPE = 'FILE';
+
+function getMetaByActivityType(structure = []) {
+  return structure.reduce((acc, { type, meta }) => {
+    const fileMetaKeys = getFileMetaKeys(meta);
+    if (!fileMetaKeys.length) return acc;
+    return { ...acc, [type]: fileMetaKeys };
+  }, {});
+}
+
+function getMetaByElementType(elementMeta = []) {
+  return elementMeta.reduce((acc, { type, inputs }) => {
+    const fileMetaKeys = getFileMetaKeys(inputs);
+    if (!fileMetaKeys.length) return acc;
+    return { ...acc, [type]: fileMetaKeys };
+  }, {});
+}
+
+function getFileMetaKeys(meta = []) {
+  return meta.filter(it => it.type === FILE_ELEMENT_TYPE).map(it => it.key);
+}
+
+module.exports = function (schemas) {
+  return schemas.reduce((acc, { id, meta, structure, elementMeta }) => {
+    return {
+      ...acc,
+      [id]: {
+        repository: getFileMetaKeys(meta),
+        activity: getMetaByActivityType(structure),
+        element: getMetaByElementType(elementMeta)
+      }
+    };
+  }, {});
+};

--- a/server/shared/util/getFileMetas.js
+++ b/server/shared/util/getFileMetas.js
@@ -22,7 +22,7 @@ function getFileMetaKeys(meta = []) {
   return meta.filter(it => it.type === FILE_ELEMENT_TYPE).map(it => it.key);
 }
 
-module.exports = function (schemas) {
+module.exports = schemas => {
   return schemas.reduce((acc, { id, meta, structure, elementMeta }) => {
     return {
       ...acc,

--- a/server/shared/util/resolveAssetURL.js
+++ b/server/shared/util/resolveAssetURL.js
@@ -25,13 +25,13 @@ const NEW_ASSET_PATH_REGEX = /(?<directory>repository\/\d+\/assets\/(?<fileName>
  * contains `targetDir`, meaning they already have the same path.
  * @param {string} assetUrl The current URL of an asset.
  * @param {string} targetDir The target directory in which an asset should be stored.
- * @return {Object} An object containing old and new directory path, or an `undefined` value if `assetUrl` includes
+ * @return {Object} An object containing old and new directory path, or an `undefined` value if `assetUrl` starts with
  * `targetDir` or if `assetsUrl` can't be matched with either regular expression.
  * @public
  */
 module.exports = (assetUrl, targetDir) => {
   if (assetUrl.startsWith(protocol)) assetUrl = assetUrl.slice(protocol.length);
-  if (assetUrl.includes(targetDir)) return;
+  if (assetUrl.startsWith(targetDir)) return;
   const result = assetUrl.match(OLD_ASSET_PATH_REGEX) || assetUrl.match(NEW_ASSET_PATH_REGEX);
   if (!result) return;
   const { groups: { directory, fileName } } = result;

--- a/server/shared/util/resolveNewURL.js
+++ b/server/shared/util/resolveNewURL.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const path = require('path');
+const { protocol } = require('../../../config/server/storage');
+
+/**
+ * The regular expression matching old assets directory structure.
+ * @type {RegExp}
+ * @const
+ * @private
+ */
+const OLD_ASSET_PATH_REGEX = /(?<directory>repository\/assets\/(?<fileName>[^?]*))/;
+
+/**
+ * The regular expression matching new assets directory structure.
+ * @type {RegExp}
+ * @const
+ * @private
+ */
+const NEW_ASSET_PATH_REGEX = /(?<directory>repository\/\d+\/assets\/(?<fileName>[^?]*))/;
+
+/**
+ * Resolves with a new asset URL if `assetUrl` can be matched with regular expression matching old, or new, assets
+ * directory structure. `undefined` value is returned in case regular expressions can't be matched or if `assetUrl`
+ * contains `targetDir`, meaning they already have the same path.
+ * @param {string} assetUrl The current URL of an asset.
+ * @param {string} targetDir The target directory in which an asset should be stored.
+ * @return {Object} An object containing old and new directory path, or an `undefined` value if `assetUrl` includes
+ * `targetDir` or if `assetsUrl` can't be matched with either regular expression.
+ * @public
+ */
+module.exports = (assetUrl, targetDir) => {
+  if (assetUrl.startsWith(protocol)) assetUrl = assetUrl.slice(protocol.length);
+  if (assetUrl.includes(targetDir)) return;
+  const result = assetUrl.match(OLD_ASSET_PATH_REGEX) || assetUrl.match(NEW_ASSET_PATH_REGEX);
+  if (!result) return;
+  const { groups: { directory, fileName } } = result;
+  const newKey = path.join(targetDir, fileName);
+  return { key: directory, newKey };
+};


### PR DESCRIPTION
This PR implements `repository clone`, `activity copy`  and `content element copy` functionalities. This is achieved by refactoring `migrateAssetsLocation` script and extracting common functionality into separate utility modules.

Issues fixed with this PR: 
- https://github.com/ExtensionEngine/tailor/issues/941
- https://github.com/ExtensionEngine/tailor/issues/942