### PR TITLE
Manually set `publishedAt` to `null` for imported activities

### DIFF
--- a/server/shared/transfer/default/processors.js
+++ b/server/shared/transfer/default/processors.js
@@ -108,7 +108,7 @@ function insertActivities(activities, depth, { context, transaction }) {
   const activityRecords = map(activities, it => {
     const parentId = context.activityIdMap[it.parentId];
     if (!parentId && depth) throw new Error('Invalid parent id');
-    Object.assign(it, { parentId, repositoryId });
+    Object.assign(it, { parentId, repositoryId, publishedAt: null });
     return omit(it, IGNORE_ATTRS);
   });
   const options = { context: { userId }, returning: true, transaction };


### PR DESCRIPTION
This PR explicitly resets imported activities `publishedAt` by setting it to `null`.