### PR TITLE
Fix `tce-audio` z-index mixed with absolute position issue

### DIFF
--- a/client/components/common/tce-core/PreviewOverlay.vue
+++ b/client/components/common/tce-core/PreviewOverlay.vue
@@ -1,6 +1,7 @@
 <template functional>
   <v-overlay
     :value="props.show"
+    z-index="0"
     opacity="0.9"
     absolute>
     <button class="message pa-2 grey--text text--lighten-2">

--- a/client/components/content-elements/tce-audio/edit/index.vue
+++ b/client/components/content-elements/tce-audio/edit/index.vue
@@ -87,7 +87,6 @@ export default {
   justify-content: center;
   position: relative;
   min-height: 4.5rem;
-  z-index: 999;
 
   ::v-deep {
     .element-placeholder {

--- a/client/components/content-elements/tce-embed/edit/index.vue
+++ b/client/components/content-elements/tce-embed/edit/index.vue
@@ -9,20 +9,18 @@
       icon="mdi-iframe"
       active-placeholder="Use toolbar to enter the url"
       active-icon="mdi-arrow-up" />
-    <template v-else>
-      <div class="content">
-        <preview-overlay :show="!isDisabled && !isFocused" />
-        <!-- Dragging iframes is not supported inside sortablejs container! -->
-        <iframe
-          v-if="!isDragged"
-          ref="frame"
-          :src="url"
-          frameborder="0"
-          sandbox="allow-forms allow-same-origin allow-scripts"
-          class="content">
-        </iframe>
-      </div>
-    </template>
+    <div v-else class="content">
+      <preview-overlay :show="!isDisabled && !isFocused" />
+      <!-- Dragging iframes is not supported inside sortablejs container! -->
+      <iframe
+        v-if="!isDragged"
+        ref="frame"
+        :src="url"
+        frameborder="0"
+        sandbox="allow-forms allow-same-origin allow-scripts"
+        class="content">
+      </iframe>
+    </div>
   </div>
 </template>
 

--- a/client/components/content-elements/tce-embed/edit/index.vue
+++ b/client/components/content-elements/tce-embed/edit/index.vue
@@ -9,7 +9,7 @@
       icon="mdi-iframe"
       active-placeholder="Use toolbar to enter the url"
       active-icon="mdi-arrow-up" />
-    <div v-else>
+    <template v-else>
       <div class="content">
         <preview-overlay :show="!isDisabled && !isFocused" />
         <!-- Dragging iframes is not supported inside sortablejs container! -->
@@ -22,7 +22,7 @@
           class="content">
         </iframe>
       </div>
-    </div>
+    </template>
   </div>
 </template>
 
@@ -67,11 +67,6 @@ export default {
 }
 
 .content {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
   width: 100%;
   height: 100%;
 }


### PR DESCRIPTION
This PR removes unnecessary z-index from `tce-audio` container and `PreviewOverlay` and absolute positioning in `tce-embed`.

**Note**: absolute positioning and z-index doesn't work together.

Fixes issue https://github.com/ExtensionEngine/tailor/issues/937 and inherently https://github.com/ExtensionEngine/tailor/issues/875.

