### PR TITLE
Fix "reinvite" user action

### DIFF
--- a/server/user/user.controller.js
+++ b/server/user/user.controller.js
@@ -64,7 +64,7 @@ function changePassword({ user, body }, res) {
 }
 
 function reinvite({ params }, res) {
-  return User.findByPk(params.id)
+  return User.unscoped().findByPk(params.id)
     .then(user => user || createError(NOT_FOUND, 'User does not exist!'))
     .then(user => User.sendInvitation(user))
     .then(() => res.status(ACCEPTED).end());


### PR DESCRIPTION
Fixes #964 

The user token from the URL is generated with the secret composed of server secret, user password, and user's "createdAt" timestamp ([source](https://github.com/ExtensionEngine/tailor/blob/develop/server/user/user.model.js#L217)). When the token is issued, the secret does not contain all of the above elements since the user instance was loaded without the password as per [the default model scope](https://github.com/ExtensionEngine/tailor/blob/develop/server/user/user.model.js#L116-L118). On the other hand, when the token is being checked, not the same secret is used because of fetching the "unscoped" user, i.e. user instance containing the password hash ([source](https://github.com/ExtensionEngine/tailor/blob/develop/server/shared/auth/index.js#L75)).

To ensure the same secret is used for both issuing and verifying the token, it's needed to load the "unscoped" user instance for creating the invitation email.