### PR TITLE
:nail_care: Reference DB port in DATABASE_URI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ PROTOCOL=http
 REVERSE_PROXY_PORT=8080
 
 # Database config
-DATABASE_URI=postgres://user:pass@hostname/database
+DATABASE_URI=postgres://user:pass@hostname:port/database
 # or
 DATABASE_NAME=
 DATABASE_USER=


### PR DESCRIPTION
This PR adds a bit of precision to the .env.example, to avoid the implication of the need for a DB port when using DATABASE_URI to configure the connection with a database. Due to experience, I was able to understand the need for it, but someone configuring Tailor for the first time might forget to add it there and end up getting a connection error.