### PR TITLE
Fix active tab highlight when a subroute is visited on the `repository-info` page

### DIFF
--- a/client/components/repository/index.vue
+++ b/client/components/repository/index.vue
@@ -12,6 +12,7 @@
           :key="tab.name"
           :to="{ name: tab.route, query: tab.query }"
           active-class="tab-active"
+          exact-path
           ripple
           class="px-4">
           <v-icon class="pr-2">mdi-{{ tab.icon }}</v-icon>{{ tab.name }}


### PR DESCRIPTION
This PR introduces a visual fix for the bug captured in the video below:

https://user-images.githubusercontent.com/6833568/178470607-941baf5f-72d6-4765-9aa1-9255493150fe.mov

On the video, you can see that visiting a subroute (clicking on `People`, thus going to `/settings/users`) will remove the highlight from `Settings`, since `Structure` has become active. The proposed fix seems to enforce the exact-path match, thus recently active (`Settings` tab) remains active. This is because `repository` route wasn't matched exactly.