### PR TITLE
Fix height and vertical alignment of the Repository Sidebar Relationship select (Prerequisites) component

### DIFF
--- a/client/components/repository/common/Sidebar/Relationship.vue
+++ b/client/components/repository/common/Sidebar/Relationship.vue
@@ -131,15 +131,13 @@ export default {
     margin-right: 1rem;
   }
 
-  .v-input__slot .v-select__slot {
-    .v-input__append-inner {
-      margin-top: 1.375rem;
-    }
+  .v-input__slot .v-select__slot input[disabled] {
+    opacity: 0.7;
+    border-bottom: unset;
+  }
 
-    input[disabled] {
-      opacity: 0.7;
-      border-bottom: unset;
-    }
+  .v-select.v-select--chips:not(.v-text-field--single).v-text-field--enclosed .v-select__selections {
+    min-height: 2.625rem;
   }
 }
 </style>

--- a/client/components/repository/common/Sidebar/Relationship.vue
+++ b/client/components/repository/common/Sidebar/Relationship.vue
@@ -18,6 +18,7 @@
       :disabled="!options.length"
       :error-messages="errors"
       :class="{ required: !allowEmpty }"
+      :height="42"
       item-value="id"
       item-text="data.name"
       deletable-chips return-object outlined>
@@ -134,10 +135,6 @@ export default {
   .v-input__slot .v-select__slot input[disabled] {
     opacity: 0.7;
     border-bottom: unset;
-  }
-
-  .v-select.v-select--chips:not(.v-text-field--single).v-text-field--enclosed .v-select__selections {
-    min-height: 2.625rem;
   }
 }
 </style>


### PR DESCRIPTION
This PR introduces a visual fix to the Prerequisites component (height and vertical alignment) found on the Repository activities sidebar. See the screenshot below to identify the page:
![screencapture-localhost-8080-2022-07-13-10_08_47](https://user-images.githubusercontent.com/6833568/178684596-aff103b0-f15a-4613-a8e7-078708645ff1.png)

Currently (on develop), the height (and thus the vertical alignment) of the placeholder and selector icon are a bit off.
![Screenshot 2022-07-13 at 09 52 55](https://user-images.githubusercontent.com/6833568/178684743-a999ead0-f269-4f17-9cb7-99a8b2f66d1a.png)

The proposed fix should make the input component get the following look in its default state:
![Screenshot 2022-07-13 at 10 08 44](https://user-images.githubusercontent.com/6833568/178684832-00a117c0-7795-440d-8e53-1da5516adfd9.png)

No regressions seem to occur when a selection has been made.
![Screenshot 2022-07-13 at 10 15 05](https://user-images.githubusercontent.com/6833568/178685301-f496427c-3733-49a2-be86-0d4a1b42431f.png)

