### PR TITLE
Fix icon code & Bump the version of @tailor-cms/core-components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@extensionengine/vue-radio": "1.0.0-beta.4",
         "@mdi/font": "^6.9.96",
         "@tailor-cms/config": "1.0.0-beta.17",
-        "@tailor-cms/core-components": "1.0.0-beta.6",
+        "@tailor-cms/core-components": "1.0.0-beta.7",
         "@tailor-cms/utils": "^1.0.0-beta.18",
         "@ungap/global-this": "^0.4.4",
         "auto-bind": "^3.0.0",
@@ -7887,9 +7887,9 @@
       }
     },
     "node_modules/@tailor-cms/core-components": {
-      "version": "1.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@tailor-cms/core-components/-/core-components-1.0.0-beta.6.tgz",
-      "integrity": "sha512-EOIyzYZfUNm54K3gIa8093w2LqpkUufX1Wpncju1UZk1KHenbl5rmIkjYz4YPBpDyBLovw40Ari3AZSC2ACX5w==",
+      "version": "1.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@tailor-cms/core-components/-/core-components-1.0.0-beta.7.tgz",
+      "integrity": "sha512-jK3hVSeLhDqoAwbO8POoFuzwKQFFQ7Kgkuq3SwioAlCFzhxDljt2HntBrdaBbh4wGL8XVS8/YDB4C9Lqq71paw==",
       "dependencies": {
         "@extensionengine/vue-radio": "^1.0.0-beta.4",
         "@tailor-cms/utils": "^1.0.0-beta.18",
@@ -40440,9 +40440,9 @@
       }
     },
     "@tailor-cms/core-components": {
-      "version": "1.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@tailor-cms/core-components/-/core-components-1.0.0-beta.6.tgz",
-      "integrity": "sha512-EOIyzYZfUNm54K3gIa8093w2LqpkUufX1Wpncju1UZk1KHenbl5rmIkjYz4YPBpDyBLovw40Ari3AZSC2ACX5w==",
+      "version": "1.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@tailor-cms/core-components/-/core-components-1.0.0-beta.7.tgz",
+      "integrity": "sha512-jK3hVSeLhDqoAwbO8POoFuzwKQFFQ7Kgkuq3SwioAlCFzhxDljt2HntBrdaBbh4wGL8XVS8/YDB4C9Lqq71paw==",
       "requires": {
         "@extensionengine/vue-radio": "^1.0.0-beta.4",
         "@tailor-cms/utils": "^1.0.0-beta.18",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@extensionengine/vue-radio": "1.0.0-beta.4",
     "@mdi/font": "^6.9.96",
     "@tailor-cms/config": "1.0.0-beta.17",
-    "@tailor-cms/core-components": "1.0.0-beta.7",
+    "@tailor-cms/core-components": "1.0.0-beta.11",
     "@tailor-cms/utils": "^1.0.0-beta.18",
     "@ungap/global-this": "^0.4.4",
     "JSONStream": "^1.3.5",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@extensionengine/vue-radio": "1.0.0-beta.4",
     "@mdi/font": "^6.9.96",
     "@tailor-cms/config": "1.0.0-beta.17",
-    "@tailor-cms/core-components": "1.0.0-beta.6",
+    "@tailor-cms/core-components": "1.0.0-beta.7",
     "@tailor-cms/utils": "^1.0.0-beta.18",
     "@ungap/global-this": "^0.4.4",
     "JSONStream": "^1.3.5",

--- a/packages/core-components/package.json
+++ b/packages/core-components/package.json
@@ -3,7 +3,7 @@
   "description": "Reusable Tailor UI components",
   "author": "ExtensionEngine <info@extensionengine.com>",
   "license": "MIT",
-  "version": "1.0.0-beta.6",
+  "version": "1.0.0-beta.7",
   "files": [
     "dist"
   ],

--- a/packages/core-components/package.json
+++ b/packages/core-components/package.json
@@ -3,7 +3,7 @@
   "description": "Reusable Tailor UI components",
   "author": "ExtensionEngine <info@extensionengine.com>",
   "license": "MIT",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.11",
   "files": [
     "dist"
   ],

--- a/packages/core-components/src/components/Discussion/ResolveButton.vue
+++ b/packages/core-components/src/components/Discussion/ResolveButton.vue
@@ -8,7 +8,7 @@
           small text
           class="px-1">
           <v-icon size="24" color="teal accent-4" class="mr-2">
-            mdi-check-box-outline
+            mdi-checkbox-outline
           </v-icon>
           Resolve All
         </v-btn>

--- a/packages/core-components/src/components/Discussion/Thread/Comment/Header.vue
+++ b/packages/core-components/src/components/Discussion/Thread/Comment/Header.vue
@@ -51,7 +51,7 @@
 import EditorLink from '@/components/EditorLink.vue';
 
 const getOptions = () => ({
-  resolve: { action: 'resolve', icon: 'check-box-outline', color: 'teal accent-4' },
+  resolve: { action: 'resolve', icon: 'checkbox-outline', color: 'teal accent-4' },
   edit: { action: 'toggleEdit', icon: 'pencil-outline', color: 'grey' },
   remove: { action: 'remove', icon: 'trash-can-outline', color: 'grey' }
 });


### PR DESCRIPTION
This PR is twofold:

1. Icon is fixed to match the code provided by the Material Design documentation.
2. Since this code lies in the `core-components` section, I've bumped the version of the `@tailor-cms/core-components` package and the main dependency.

@underscope please take a look to verify that you are able to reproduce the issue and that my fix will be correctly propagated through the `npm install`. Thanks!
cc @mskorsur 

Current state of things:
![Screenshot 2022-07-13 at 13 20 49](https://user-images.githubusercontent.com/6833568/178722232-fda7d38d-63c6-4708-aa76-bf21407c61b3.png)


Once the fix lands, it should look like this:
![Screenshot 2022-07-13 at 13 07 08](https://user-images.githubusercontent.com/6833568/178722221-3ce9c9fa-619f-4305-81c2-9e669a14c6de.png)

Also fixes the missing icon here:
![Screenshot 2022-07-13 at 14 17 14](https://user-images.githubusercontent.com/6833568/178731476-1e895e34-0c1d-471b-b7a9-f8ed8ba6dece.png)

Overall:
![Screenshot 2022-07-13 at 14 18 20](https://user-images.githubusercontent.com/6833568/178731642-4c94066b-b0cc-407d-acce-397aca26c377.png)

