### PR TITLE
Fix color meta label aligment

### DIFF
--- a/client/components/meta-inputs/meta-color/Edit/index.vue
+++ b/client/components/meta-inputs/meta-color/Edit/index.vue
@@ -95,6 +95,7 @@ $gutter: 0.375rem;
     font-size: 0.875rem;
     font-weight: normal;
     line-height: 1rem;
+    text-align: left;
   }
 }
 


### PR DESCRIPTION
- Should be aligned to the left

Before:
<img width="471" alt="image" src="https://user-images.githubusercontent.com/6253820/180975145-180c80b9-2ef7-40f0-8195-d02a17530856.png">

After:
<img width="471" alt="image" src="https://user-images.githubusercontent.com/6253820/180975219-31e5735c-da45-410f-a7a6-0f09a1a5bf2d.png">
