### PR TITLE
Bump Node to `>= 20.3.1`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   default-executor: &default-executor
     docker:
-      - image: cimg/node:16.16.0
+      - image: cimg/node:20.3.1
   machine-executor: &machine-executor
     machine:
       image: ubuntu-2004:2022.04.1
@@ -12,7 +12,7 @@ default_directory: &default-directory
   working_directory: ~/deploy/tailor
 
 orbs:
-  node: circleci/node@5.0.2
+  node: circleci/node@5.1.0
   shellcheck: circleci/shellcheck@3.1.1
 
 dev-env-defaults: &dev-env-defaults
@@ -34,7 +34,7 @@ jobs:
     steps:
       - checkout
       - node/install:
-          node-version: '16.16'
+          node-version: '20.3.1'
       - node/install-packages
       - run:
           name: Setup environment variables

--- a/package.json
+++ b/package.json
@@ -200,8 +200,8 @@
     "vue-template-compiler": "^2.7.14"
   },
   "engines": {
-    "node": ">= 16.16.0",
-    "npm": ">= 8.11.0",
+    "node": ">= 20.3.1",
+    "npm": ">= 9.6.0",
     "postgres": ">= 9.4"
   }
 }


### PR DESCRIPTION
Also bumps npm to `>= 9.6.0` and updates CircleCI config to use appropriate Node version.
Node is bumped to a specific version `>= 20.3.1` as it includes OpenSSL security updates,
https://nodejs.org/en/blog/vulnerability/june-2023-security-releases.