### PR TITLE
CIMA-1890: Add edit button on top of knowledge checks

### DIFF
--- a/client/components/common/tce-core/QuestionContainer/index.vue
+++ b/client/components/common/tce-core/QuestionContainer/index.vue
@@ -9,6 +9,14 @@
       <span class="subtitle-2">{{ config.name }}</span>
     </v-toolbar>
     <slot :isEditing="isEditing"></slot>
+    <controls
+      v-if="!isDisabled"
+      @edit="edit"
+      @save="save"
+      @cancel="cancel"
+      :is-editing="isEditing"
+      :has-errors="hasErrors"
+      class="controls" />
     <question
       @update="update"
       :assessment="editedElement"
@@ -46,14 +54,6 @@
         class="mt-4">
         {{ alert.text }}
       </v-alert>
-      <controls
-        v-if="!isDisabled"
-        @edit="edit"
-        @save="save"
-        @cancel="cancel"
-        :is-editing="isEditing"
-        :has-errors="hasErrors"
-        class="controls" />
     </div>
   </v-card>
 </template>
@@ -197,7 +197,7 @@ const baseSchema = {
     overflow: hidden;
   }
 
-  .content {
+  .content, .controls {
     padding: 0.5rem 1.625rem;
 
     @media (max-width: 1263px) {


### PR DESCRIPTION
- 'Add an Edit button to the top of the Knowledge checks. Knowledge checks can be long and when making a change, it now requires me to go to the bottom of the KC to click Edit, then move back up to the top to make changes in the question area. When working in Tailor, I would start at the top and page down until I find the KC. It would be great to just click edit there instead of moving to the bottom, then back up.'